### PR TITLE
푸터 수정 및 임시저장 페이지 구현, 임시저장 페이지에서 수정페이지로 이동 구현

### DIFF
--- a/src/Components/Calendar/EndDate.tsx
+++ b/src/Components/Calendar/EndDate.tsx
@@ -3,7 +3,7 @@ import DatePicker from 'react-datepicker';
 import { useState, ChangeEvent } from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 import styled from 'styled-components';
-import { OptionalCreates } from '@/Pages/Studies/GatherStudy';
+import { OptionalCreates } from '@/Pages/Studies/CreateRecruitment';
 import { Creates } from '@/Types/studies';
 
 export type Props = {

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -8,35 +8,23 @@ export const Footer = () => {
         <FooterText>스터디 모집 공고 모아보기</FooterText>
         <FooterText>마이 페이지</FooterText>
         <BorderBox />
-
         <FooterBottom>
-          <AssetContainer>
-            <Ludo_Footer />
-          </AssetContainer>
-          {/* <ArticleTitles>함께 발견하는 가능성, 기회의 연결!</ArticleTitles>
-          <Articles>CopyrightⓒLudo All rights reserved.</Articles>
-          <Articles>[BE] 빽 , 아카 , 휴 | [FE] 타로 , 현 | [DE] 포키</Articles>
-          <ArticleContainer>
-            <Articles></Articles>
-          </ArticleContainer> */}
+          <Ludo_Footer />
+          <MiddleWrapper>
+            <ArticleTitles>함께 발견하는 가능성, 기회의 연결!</ArticleTitles>
+            <Articles>CopyrightⓒLudo All rights reserved.</Articles>
+            <Articles>[BE] 빽 , 아카 , 휴 | [FE] 타로 , 현 | [DE] 포키 </Articles>
+          </MiddleWrapper>
+          <LastWrapper>
+            <FooterText>서비스 소개</FooterText>
+            <FooterText>이용약관</FooterText>
+            <FooterText>개인정보 처리방침</FooterText>
+          </LastWrapper>
         </FooterBottom>
       </FooterWrapper>
-
-      {/* <Ludo_Footer />
-      <FooterBottom>
-        <ArticleContainer>
-          <ArticleTitles>함께 발견하는 가능성, 기회의 연결!</ArticleTitles>
-          <Articles>CopyrightⓒLudo All rights reserved.</Articles>
-          <Articles>[BE] 빽 , 아카 , 휴 | [FE] 타로 , 현 | [DE] 포키 </Articles>
-        </ArticleContainer>
-      </FooterBottom> */}
     </FooterContainer>
   );
 };
-
-const AssetContainer = styled.div`
-  align-items: center;
-`;
 
 const FooterContainer = styled.section`
   display: flex;
@@ -45,6 +33,14 @@ const FooterContainer = styled.section`
   flex-direction: row;
   margin-top: 40px;
   background-color: ${({ theme }) => theme.color.gray1};
+`;
+
+const MiddleWrapper = styled.div`
+  display: grid;
+  grid-template-rows: 30px 30px 30px;
+  flex-direction: row;
+  grid-template-columns: 504px;
+  padding-bottom: 24px;
 `;
 
 const BorderBox = styled.span`
@@ -61,17 +57,21 @@ const FooterWrapper = styled.div`
   flex-direction: row;
 `;
 
-const FooterBottom = styled.div`
-  flex-direction: row;
-  padding-bottom: 40px;
-  padding-top: 32px;
-  margin: auto;
+const LastWrapper = styled.div`
+  display: grid;
+  grid-template-rows: 78px;
+  grid-template-columns: 101px 101px 150px;
 `;
 
-const ArticleContainer = styled.div`
-  flex-direction: column;
-  /* height: 78px; */
+const FooterBottom = styled.div`
+  padding-bottom: 40px;
+  padding-top: 32px;
+  gap: 24px;
+  display: grid;
+  grid-template-rows: 78px;
+  grid-template-columns: 180px 513px 513px;
 `;
+
 const ArticleTitles = styled.span`
   font-size: 20px;
   font-style: normal;

--- a/src/Components/RecruitmentCard/index.tsx
+++ b/src/Components/RecruitmentCard/index.tsx
@@ -3,7 +3,7 @@ import PositionSection from './PositionSection';
 import { Position, RecruitmentInfoType, StudyBasicInfoType, ProgressInfoType } from '@/Types/study';
 import { BlankSquare } from '../Common/BlankSquare';
 import { Link } from 'react-router-dom';
-import { dateFormatter } from '@/utils/date';
+import { dateFormatter } from '@/Utils/date';
 
 export type RecruitmentCardProps = Pick<StudyBasicInfoType, 'category'> &
   Omit<RecruitmentInfoType, 'applicantCnt' | 'contact' | 'platformUrl' | 'detail' | 'isModified'> &

--- a/src/Components/Selectbox/GatherButton.tsx
+++ b/src/Components/Selectbox/GatherButton.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { ChangeEvent, useState } from 'react';
-import { OptionalCreates } from '@/Pages/Studies/GatherStudy';
+import { OptionalCreates } from '@/Pages/Studies/CreateRecruitment';
 import { Creates } from '@/Types/studies';
 
 export type Props = {

--- a/src/Components/Selectbox/StackSelectButton.tsx
+++ b/src/Components/Selectbox/StackSelectButton.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { OptionalCreates } from '@/Pages/Studies/GatherStudy';
+import { OptionalCreates } from '@/Pages/Studies/CreateRecruitment';
 import { Creates, ItemCategory } from '@/Types/studies';
 import { ChangeEvent, useState, useRef } from 'react';
 import { StackItem } from '@/Types/studies';

--- a/src/Components/Textarea/ContactUrlInput.tsx
+++ b/src/Components/Textarea/ContactUrlInput.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, ChangeEvent } from 'react';
 import styled from 'styled-components';
-import { OptionalCreates } from '@/Pages/Studies/GatherStudy';
+import { OptionalCreates } from '@/Pages/Studies/CreateRecruitment';
 import { Creates } from '@/Types/studies';
 
 export type Props = {

--- a/src/Components/Textarea/Mainarea.tsx
+++ b/src/Components/Textarea/Mainarea.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, ChangeEvent } from 'react';
 import styled from 'styled-components';
-import { OptionalCreates } from '@/Pages/Studies/GatherStudy';
+import { OptionalCreates } from '@/Pages/Studies/CreateRecruitment';
 import { Creates } from '@/Types/studies';
 
 export type Props = {

--- a/src/Constants/Router_Path.ts
+++ b/src/Constants/Router_Path.ts
@@ -10,9 +10,9 @@ export const ROUTER_PATH = {
   recruitments: '/studies', //스터디 모아보기 페이지
   createStudy: '/studies/create', //스터디생성페이지
   modifyStudy: 'studies/modify',
-  gatherStudy: 'studies/gather',
+  gatherStudy: 'studies/recruitment',
   decativate: '/deactivate', //회원탈퇴 페이지
   test: '/test',
-  save: '/mypage/save',
+  savestudy: '/mypage/savestudy',
   applicants: '/studies/:studyId/applicants', //지원자 확인 페이지
 } as const;

--- a/src/Mocks/browser.ts
+++ b/src/Mocks/browser.ts
@@ -1,4 +1,4 @@
-import { setupWorker } from 'msw/browser';
-import { handlers } from './handlers';
+// import { setupWorker } from 'msw/browser';
+// import { handlers } from './handlers';
 
-export const worker = setupWorker(...handlers);
+// export const worker = setupWorker(...handlers);

--- a/src/Pages/Studies/CreateRecruitment.tsx
+++ b/src/Pages/Studies/CreateRecruitment.tsx
@@ -17,15 +17,13 @@ import { useState } from 'react';
 import { useStack } from '@/Apis/stack';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { httpClient } from '@/Utils/axios';
 import { One, Two, Three, Four } from '@/Assets';
 import { SaveButton } from '@/Components/Button/Studies/SaveButton';
-// import { Border } from '@/Assets';
 
 axios.defaults.withCredentials = true;
 export type OptionalCreates = Partial<Gather>;
 
-export const GatherStudy = () => {
+export const CreateRecruitment = () => {
   const Navigation = useNavigate();
   const [useForm, setuseForm] = useState<Gather>({
     title: '',
@@ -57,7 +55,7 @@ export const GatherStudy = () => {
       callUrl: useForm.callUrl,
       content: useForm.content,
       // studyId: useForm.studyId,
-      studyId: 47,
+      studyId: 50,
     });
     console.log(data);
     localStorage.setItem('gather', JSON.stringify(data.data));

--- a/src/Pages/Studies/ModifyStudy.tsx
+++ b/src/Pages/Studies/ModifyStudy.tsx
@@ -8,8 +8,29 @@ import { CalendarButton } from '../../Components/Selectbox/CalendarButton';
 import { BigCategoryButton } from '../../Components/Selectbox/BigCategoryButton';
 import { ProgressPeriod } from '../../Components/Calendar/ProgressPeriod';
 import { media } from '../../Styles/theme';
-
+import { useState } from 'react';
+import { Creates } from '@/Types/studies';
+import { useNavigate } from 'react-router-dom';
+export type OptionalCreates = Partial<Creates>;
 export const ModifyStudy = () => {
+  const Navigate = useNavigate();
+  const [useForm, setuseForm] = useState<Creates>({
+    title: '',
+    categoryId: 0,
+    way: '',
+    participantLimit: 0,
+    startDateTime: '',
+    endDateTime: '',
+    positionId: 0,
+    platform: '',
+  });
+
+  function forms(fields: OptionalCreates) {
+    setuseForm({
+      ...useForm,
+      ...fields,
+    });
+  }
   return (
     <>
       <StudyContainer>
@@ -18,7 +39,7 @@ export const ModifyStudy = () => {
           <StudyTitle>스터디 제목</StudyTitle>
           <BottomWrapper>
             <ContentText>제목</ContentText>
-            <Titlearea />
+            <Titlearea setForm={forms} useForm={useForm} />
           </BottomWrapper>
         </TopBox>
         <MiddleBox>
@@ -27,11 +48,11 @@ export const ModifyStudy = () => {
             <MiddleBottomInfo>
               <MiddleBottomWrapper>
                 <ContentText>카테고리</ContentText>
-                <BigCategoryButton />
+                <BigCategoryButton setForm={forms} useForm={useForm} />
               </MiddleBottomWrapper>
               <MiddleBottomWrapper>
                 <ContentText>스터디 최대 인원</ContentText>
-                <BigCategoryButton />
+                <BigCategoryButton setForm={forms} useForm={useForm} />
               </MiddleBottomWrapper>
             </MiddleBottomInfo>
           </MiddleWrapper>
@@ -41,16 +62,16 @@ export const ModifyStudy = () => {
           <StudyMiddleInfo>
             <StudyWrapper>
               <ContentText>진행방식</ContentText>
-              <ProgressButton />
+              <ProgressButton setForm={forms} useForm={useForm} />
             </StudyWrapper>
             <StudyWrapper>
               <ContentText>진행 플랫폼</ContentText>
-              <PlatformButton />
+              <PlatformButton setForm={forms} useForm={useForm} />
             </StudyWrapper>
             <StudyWrapper>
               <ContentText> 진행기간</ContentText>
               <CalendarButton>
-                <ProgressPeriod />
+                <ProgressPeriod setForm={forms} useForm={useForm} />
               </CalendarButton>
             </StudyWrapper>
           </StudyMiddleInfo>

--- a/src/Pages/Studies/Save.tsx
+++ b/src/Pages/Studies/Save.tsx
@@ -1,7 +1,0 @@
-export const Save = () => {
-  return (
-    <div>
-      <div>ada</div>
-    </div>
-  );
-};

--- a/src/Pages/Studies/SaveStudy.tsx
+++ b/src/Pages/Studies/SaveStudy.tsx
@@ -1,0 +1,104 @@
+import styled from 'styled-components';
+import { SaveButton } from '@/Components/Button/Studies/SaveButton';
+import { SubmitButton } from '../../Components/Button/Studies/SubmitButton';
+import { useNavigate } from 'react-router-dom';
+export const SaveStudy = () => {
+  const localData = JSON.parse(localStorage.getItem('create'));
+  // console.log(localData.study);
+  const navigate = useNavigate();
+  const navigateToModify = () => {
+    navigate('/studies/modify');
+  };
+  return (
+    <StudyContainer onSubmit={navigateToModify}>
+      <StudyTitle>{JSON.stringify(localData.study.title)}</StudyTitle>
+      <TopWrapper>
+        <StudySub>카테고리</StudySub>
+        <StudyContents>{JSON.stringify(localData.study.category.name)}</StudyContents>
+        <StudySub>스터디 최대인원</StudySub>
+        <StudyContents>{JSON.stringify(localData.study.participantLimit)}</StudyContents>
+      </TopWrapper>
+      <BorderBox />
+      <BottomWrapper>
+        <StudySub>진행 방식</StudySub>
+        <StudyContents>{JSON.stringify(localData.study.way)}</StudyContents>
+        <StudySub>진행 플랫폼</StudySub>
+        <StudyContents>{JSON.stringify(localData.study.platform)}</StudyContents>
+        <StudySub>진행 기간</StudySub>
+        <StudyContents>
+          {JSON.stringify(localData.study.startDateTime)}~{JSON.stringify(localData.study.endDateTime)}
+        </StudyContents>
+        <StudySub>진행 기간</StudySub>
+        <StudyContents>D-</StudyContents>
+      </BottomWrapper>
+      <ButtonBox>
+        <SaveButton type="submit">글 삭제하기</SaveButton>
+        <SubmitButton type="submit">이어서 작성하기</SubmitButton>
+      </ButtonBox>
+    </StudyContainer>
+  );
+};
+
+const BorderBox = styled.div`
+  width: 1200px;
+  border-bottom: 1px solid black;
+`;
+const StudyContainer = styled.form`
+  height: 1300px;
+  padding-top: 40px;
+  padding-left: 348px;
+  padding-right: 348px;
+  flex-direction: row;
+  text-align: left;
+`;
+
+const TopWrapper = styled.div`
+  display: grid;
+  grid-template-rows: 50px;
+  flex-direction: row;
+  grid-template-columns: 184px 392px 184px 392px;
+  row-gap: 24px;
+  column-gap: 24px;
+  padding-bottom: 24px;
+`;
+
+const BottomWrapper = styled.div`
+  padding-top: 24px;
+  display: grid;
+  grid-template-rows: 50px 50px;
+  flex-direction: row;
+  grid-template-columns: 184px 392px 184px 392px;
+  row-gap: 24px;
+  column-gap: 24px;
+  padding-bottom: 24px;
+`;
+
+const StudyTitle = styled.p`
+  font-size: ${(props) => props.theme.font.xlarge};
+  font-weight: bold;
+  align-items: left;
+  padding-bottom: 30px;
+`;
+
+const StudySub = styled.p`
+  font-family: Pretendard;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 30px;
+`;
+const StudyContents = styled.p`
+  color: gray;
+  font-family: Pretendard;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 30px;
+`;
+
+const ButtonBox = styled.div`
+  padding-top: 60px;
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+`;

--- a/src/Router/index.tsx
+++ b/src/Router/index.tsx
@@ -4,7 +4,7 @@ import MyPage from '../Pages/MyPage';
 import { Login } from '../Pages/Login';
 import { CreateStudy } from '../Pages/Studies/CreateStudy';
 import { ModifyStudy } from '../Pages/Studies/ModifyStudy';
-import { GatherStudy } from '../Pages/Studies/GatherStudy';
+import { CreateRecruitment } from '../Pages/Studies/CreateRecruitment';
 import Main from '../Pages/Main';
 import RecruitmentDetail from '../Pages/RecruitmentDetail';
 import Recruitments from '../Pages/Recruitments';
@@ -13,8 +13,7 @@ import Header from '@/Components/Header';
 import ApplicantsPage from '@/Pages/Applicants';
 import StudyDetailPage from '@/Pages/StudyDetail';
 import { Footer } from '@/Components/Footer/Footer';
-import { Save } from '@/Pages/Studies/Save';
-
+import { SaveStudy } from '@/Pages/Studies/SaveStudy';
 
 export const RouterPath = createBrowserRouter([
   {
@@ -48,7 +47,7 @@ export const RouterPath = createBrowserRouter([
       },
       {
         path: ROUTER_PATH.gatherStudy,
-        element: <GatherStudy />,
+        element: <CreateRecruitment />,
       },
 
       {
@@ -72,8 +71,8 @@ export const RouterPath = createBrowserRouter([
         element: <ApplicantsPage />,
       },
       {
-        path: ROUTER_PATH.save,
-        element: <Save />,
+        path: ROUTER_PATH.savestudy,
+        element: <SaveStudy />,
       },
     ],
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,21 +2,21 @@ import ReactDOM from 'react-dom/client';
 import { StrictMode } from 'react';
 import App from './App.tsx';
 
-const enableMocking = async () => {
-  if (import.meta.env.DEV === false) return;
-  const { worker } = await import('./Mocks/browser');
-  return worker.start();
-};
+// const enableMocking = async () => {
+//   if (import.meta.env.DEV === false) return;
+//   const { worker } = await import('./Mocks/browser');
+//   return worker.start();
+// };
 
-enableMocking().then(() =>
-  ReactDOM.createRoot(document.getElementById('root')!).render(
-    <StrictMode>
-      <App />
-    </StrictMode>,
-  ),
-);
-// ReactDOM.createRoot(document.getElementById('root')!).render(
-//   <StrictMode>
-//     <App />
-//   </StrictMode>,
+// enableMocking().then(() =>
+//   ReactDOM.createRoot(document.getElementById('root')!).render(
+//     <StrictMode>
+//       <App />
+//     </StrictMode>,
+//   ),
 // );
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);


### PR DESCRIPTION
=
### 💡 다음 이슈를 해결했어요.
- 임시저장 페이지 기능 구현
- 수정페이지로 이동 구현
- footer 스타일 수정


![임시저장페이지](https://github.com/Ludo-SMP/ludo-frontend/assets/53456037/f68905cd-52d9-4543-afb4-bf161da18707)


### 💡 필요한 후속작업이 있어요.
- 수정 페이지 작업 , 스타일 수정
- 월요일에 배포되는 여분의 api작업

### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
