### PR TITLE
모집공고 지원 시, 지원 성공 및 실패에 대한 로직 수정 구현

### DIFF
--- a/src/Components/Calendar/EndDate.tsx
+++ b/src/Components/Calendar/EndDate.tsx
@@ -21,9 +21,9 @@ export type Props = {
   ref?: string;
 };
 
-export const EndDate = ({ setForm, useForm }: Props) => {
+export const EndDate = ({ useForm }: Props) => {
   const [startDateTime, setForms] = useState(new Date());
-  console.log(setForm);
+
   return (
     <DateContainer
       value={(useForm.recruitmentEndDateTime = startDateTime.toISOString().slice(0, -5))}

--- a/src/Components/Calendar/ProgressPeriod.tsx
+++ b/src/Components/Calendar/ProgressPeriod.tsx
@@ -21,13 +21,12 @@ export type Props = {
   ref?: string;
 };
 
-export const ProgressPeriod = ({ setForm, useForm }: Props) => {
+export const ProgressPeriod = ({ useForm }: Props) => {
   const [startDateTime, setForms] = useState(new Date());
   const [endDateTime, setFormss] = useState(new Date());
   // const StartHandler = (event: ChangeEvent<HTMLSelectElement>) => {
   //   setForm({ startDateTime: event.target.value });
   // };
-  console.log(setForm);
 
   return (
     <>

--- a/src/Components/Textarea/Titlearea.tsx
+++ b/src/Components/Textarea/Titlearea.tsx
@@ -23,8 +23,7 @@ export type Props = {
 
 export const Titlearea = ({ setForm, useForm }: Props) => {
   // const [inputValue, setForms] = useState('');
-  // console.log(inputValue);
-  // console.log(setForms);
+
   // const [inputValue, setForms] = useState('');
   const onValueHandler = (event: ChangeEvent<HTMLTextAreaElement>) => {
     setForm({ title: event.target.value });

--- a/src/Hooks/study/useApplyStudyMutation.ts
+++ b/src/Hooks/study/useApplyStudyMutation.ts
@@ -4,6 +4,7 @@ import { useModalStore } from '@/store/modal';
 import { useMutation } from '@tanstack/react-query';
 import { applyStudy } from '@/Apis/study';
 import { STUDY } from '@/Constants/queryString';
+import { AxiosError } from 'axios';
 
 export const useApplyStudyMutation = (
   studyId: number,
@@ -18,10 +19,11 @@ export const useApplyStudyMutation = (
       handleApplyApprove('SUCCESS');
       openModal();
     },
-    onError: () => {
-      // const message = e?.response?.data?.message;
-      // if (message === '현재 모집 중인 스터디가 아닙니다.') handleApplyApprove(() => 'CLOSED');
-      // if (message === '이미 지원한 모집 공고입니다.') handleApplyApprove(() => 'ALREDAY_APPLY');
+    onError: (e: AxiosError<{ ok: boolean; message: string; data: null }>) => {
+      const errorMessage = e.response.data?.message;
+      if (errorMessage === '이미 지원한 모집 공고입니다.') handleApplyApprove(() => 'ALREDAY_APPLY');
+      if (errorMessage === '이미 수락된 모집 공고입니다.') handleApplyApprove(() => 'ALREDY_PARTICIPATED');
+      if (errorMessage === '현재 모집 중인 스터디가 아닙니다.') handleApplyApprove(() => 'CLOSED');
       openModal();
     },
   });

--- a/src/Pages/RecruitmentDetail/index.tsx
+++ b/src/Pages/RecruitmentDetail/index.tsx
@@ -147,18 +147,32 @@ const RecruitmentDetailPage = () => {
               <div className="approve__image"></div>
             </Modal>
           )}
-          {isLoggedIn && isModalOpen && (applyTryStatus === 'CLOSED' || applyTryStatus === 'ALREDAY_APPLY') && (
-            <Modal
-              title={applyTryStatus === 'CLOSED' ? APPLY.CLOSED.title : APPLY.ALREADY_APPLY.title}
-              handleApprove={() => {
-                setApplyTryStatus(() => 'NOT APPLY');
-                closeModal();
-              }}
-              approveBtnText="확인"
-            >
-              {applyTryStatus === 'CLOSED' ? APPLY.CLOSED.content : APPLY.ALREADY_APPLY.content}
-            </Modal>
-          )}
+          {isLoggedIn &&
+            isModalOpen &&
+            (applyTryStatus === 'CLOSED' ||
+              applyTryStatus === 'ALREDAY_APPLY' ||
+              applyTryStatus === 'ALREDY_PARTICIPATED') && (
+              <Modal
+                title={
+                  applyTryStatus === 'CLOSED'
+                    ? APPLY.CLOSED.title
+                    : applyTryStatus === 'ALREDAY_APPLY'
+                    ? APPLY.ALREADY_APPLY.title
+                    : APPLY.ALREADY_PARTICIPATED.title
+                }
+                handleApprove={() => {
+                  setApplyTryStatus(() => 'NOT APPLY');
+                  closeModal();
+                }}
+                approveBtnText="확인"
+              >
+                {applyTryStatus === 'CLOSED'
+                  ? APPLY.CLOSED.content
+                  : applyTryStatus === 'ALREDAY_APPLY'
+                  ? APPLY.ALREADY_APPLY.content
+                  : APPLY.ALREADY_PARTICIPATED.content}
+              </Modal>
+            )}
         </>
       )}
     </RecruitmentDetailWrapper>


### PR DESCRIPTION
Closes #126 
### 💡 다음 이슈를 해결했어요.
- [x] 모집공고 지원 시, 지원 성공 및 실패에 대한 로직 수정 
- [x] 모집공고 지원 시, 지원 성공 및 실패 시 모달을 통해 결과를 보여주는 기능

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

### 💡 필요한 후속작업이 있어요.

### 💡 다음 자료를 참고하면 좋아요.

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
