### PR TITLE
아코디언 컴포넌트 구현

### DIFF
--- a/src/Assets/SelectArrow.tsx
+++ b/src/Assets/SelectArrow.tsx
@@ -11,6 +11,9 @@ export const SelectArrow = ({ isOpen }: SelectArrowProps) => {
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      style={{
+        transition: 'transform 0.3s ease',
+      }}
     >
       <path
         id="Vector"

--- a/src/Assets/SelectArrow.tsx
+++ b/src/Assets/SelectArrow.tsx
@@ -1,6 +1,17 @@
-export const SelectArrow = () => {
+interface SelectArrowProps {
+  isOpen?: boolean;
+}
+
+export const SelectArrow = ({ isOpen }: SelectArrowProps) => {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      width="24"
+      height="24"
+      transform={`${isOpen ? 'rotate(180)' : 'rotate(0)'}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <path
         id="Vector"
         d="M20.9999 7.92031C20.9999 8.07391 20.9414 8.22751 20.8241 8.34451L12.8339 16.335C12.374 16.7949 11.6258 16.7949 11.1662 16.335L3.17572 8.34451C2.94142 8.11021 2.94142 7.73041 3.17572 7.49611C3.41002 7.26181 3.78982 7.26181 4.02412 7.49611L11.9999 15.4719L19.9757 7.49611C20.21 7.26181 20.5898 7.26181 20.8241 7.49611C20.9414 7.61341 20.9999 7.76671 20.9999 7.92031Z"

--- a/src/Components/Accordion/Accordion.stories.ts
+++ b/src/Components/Accordion/Accordion.stories.ts
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Accordion } from '.';
+
+const meta = {
+  component: Accordion,
+} satisfies Meta<typeof Accordion>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    title: '알림 제목',
+    children: '알림 내용',
+  },
+} satisfies Story;
+
+export const Description: Story = {
+  args: {
+    title: '알림 제목',
+    description: '알림 설명',
+    children: '알림 내용',
+  },
+} satisfies Story;

--- a/src/Components/Accordion/index.tsx
+++ b/src/Components/Accordion/index.tsx
@@ -18,7 +18,7 @@ export interface AccordionProps {
 const Accordion = (props: AccordionProps) => {
   const { title, description, children } = props;
 
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState<boolean | null>(null);
 
   const [contentHeight, setContentHeight] = useState<number>(0);
 
@@ -26,7 +26,8 @@ const Accordion = (props: AccordionProps) => {
 
   useEffect(() => {
     setContentHeight(contentRef?.current?.clientHeight ?? 0);
-  });
+    setIsOpen(null);
+  }, []);
 
   return (
     <Container>
@@ -95,7 +96,7 @@ export const Description = styled.div`
   ${textEllipsis}
 `;
 
-const AccordionDetail = styled.p<{ isOpen?: boolean; contentHeight: number }>`
+const AccordionDetail = styled.p<{ isOpen?: null | boolean; contentHeight: number }>`
   min-width: 300px;
   padding: 8px 64px 8px 0px;
   gap: 16px;
@@ -115,7 +116,8 @@ const AccordionDetail = styled.p<{ isOpen?: boolean; contentHeight: number }>`
             opacity 0.7s ease-in-out,
             visibility 0.4s ease-in-out;
         `
-      : css`
+      : typeof isOpen === 'boolean' &&
+        css`
           transition:
             margin-top 0.2s ease-in-out,
             opacity 0.3s ease-in-out;

--- a/src/Components/Accordion/index.tsx
+++ b/src/Components/Accordion/index.tsx
@@ -1,0 +1,125 @@
+import { SelectArrow } from '@/Assets/SelectArrow';
+import { textEllipsis } from '@/Styles/theme';
+import { useEffect, useRef, useState } from 'react';
+import styled, { css } from 'styled-components';
+
+export interface AccordionProps {
+  /** 아코디언 써머리 영역에 나타날 제목 */
+  title: string;
+
+  /** 아코디언 제목 아래의 설명 */
+  description?: string;
+
+  /** 아코디언을 펼쳤을 때 나타날 내용 */
+  children?: React.ReactNode;
+}
+
+/** 마이페이지 아코디언 */
+const Accordion = (props: AccordionProps) => {
+  const { title, description, children } = props;
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const [contentHeight, setContentHeight] = useState<number>(0);
+
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setContentHeight(contentRef?.current?.clientHeight ?? 0);
+  });
+
+  return (
+    <Container>
+      <AccordionSummary onClick={() => setIsOpen((prev) => !prev)}>
+        <SummaryWrap>
+          <Title>{title}</Title>
+          {description && <Description>{description}</Description>}
+        </SummaryWrap>
+        <SelectArrow isOpen={isOpen} />
+      </AccordionSummary>
+
+      <AccordionDetail ref={contentRef} isOpen={isOpen} contentHeight={contentHeight}>
+        {children}
+      </AccordionDetail>
+    </Container>
+  );
+};
+
+const SummaryWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  width: calc(100% - 24px);
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 808px;
+  padding: 16px 0px;
+  gap: 10px;
+`;
+
+const AccordionSummary = styled.div`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  cursor: pointer;
+  min-width: 300px;
+  background-color: ${({ theme }) => theme.color.white};
+  min-height: 56px;
+`;
+
+export const Title = styled.div`
+  color: ${({ theme }) => theme.color.black5};
+
+  /* TODO: 타이포 브랜치 머지 후, typo 적용 */
+  /* Page/Sub Title-Medium */
+  font-family: 'Pretendard500';
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 32px;
+
+  ${textEllipsis}
+`;
+
+export const Description = styled.div`
+  color: ${({ theme }) => theme.color.black2};
+
+  /* TODO: 타이포 브랜치 머지 후, typo 적용 */
+  /* List,Alert/Lable-Medium */
+  font-family: 'Pretendard400';
+  font-size: 16px;
+  line-height: 24px;
+
+  ${textEllipsis}
+`;
+
+const AccordionDetail = styled.p<{ isOpen?: boolean; contentHeight: number }>`
+  min-width: 300px;
+  padding: 8px 64px 8px 0px;
+  gap: 16px;
+
+  visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
+  opacity: 0;
+
+  margin-top: -${({ contentHeight }) => contentHeight}px;
+
+  ${({ isOpen }) =>
+    isOpen
+      ? css`
+          opacity: 1;
+          margin-top: 0;
+          transition:
+            margin-top 0.2s ease-in-out,
+            opacity 0.7s ease-in-out,
+            visibility 0.4s ease-in-out;
+        `
+      : css`
+          transition:
+            margin-top 0.2s ease-in-out,
+            opacity 0.3s ease-in-out;
+        `}
+`;
+
+export { Accordion };

--- a/src/Styles/theme.ts
+++ b/src/Styles/theme.ts
@@ -1,5 +1,5 @@
 // theme.ts
-import { DefaultTheme } from 'styled-components';
+import { DefaultTheme, css } from 'styled-components';
 
 export const color = {
   white: '#ffffff',
@@ -74,3 +74,9 @@ export const theme: DefaultTheme = {
   borderRadius,
   buttonSize,
 };
+
+export const textEllipsis = css`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;


### PR DESCRIPTION
closes #178 

### 💡 다음 이슈를 해결했어요.

- 아코디언이 열린 경우, 화살표 180도 회전합니다.
- 열릴 때랑 닫힐 때, transition을 적용해서 스르륵 열립니다.
- AccordionDetail( 펼쳤을 때 나오는 내용)의 height가 길면 스르륵 열릴 때, 시간이 오래걸리는 문제가 있어서 contentHeight 을 구하는 ref를 달았습니다. 
-  Accordion 써머리의 제목이나 내용이 width를 초과할 경우, 잘리는 내용을 "..." 으로 표시했습니다.

### 실행영상

https://github.com/Ludo-SMP/ludo-frontend/assets/71035113/af251f36-31aa-4b33-a14e-ff34b22cec3d


### Accordion 써머리의 제목이나 내용이 width를 초과할 경우, 잘리는 내용을 "..." 으로 표시

https://github.com/Ludo-SMP/ludo-frontend/assets/71035113/211c8c6d-d89b-4180-bce6-a42f53584f64


### 제목만 있는 경우
<img width="500" alt="image" src="https://github.com/Ludo-SMP/ludo-frontend/assets/71035113/ba177dc6-99ad-42c2-b64c-be1bdc6e091e">

### 제목 + 설명이 있는 경우
<img width="500" alt="image" src="https://github.com/Ludo-SMP/ludo-frontend/assets/71035113/a46adf69-5330-47ba-a4fc-45d4316651f5">


### 💡 필요한 후속작업이 있어요.
- typography 브랜치 머지 후 타이포 적용


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
