### PR TITLE
페이지 상단 바(TopBar) 컴포넌트 구현

### DIFF
--- a/src/Components/Topbar/Tobar.stories.ts
+++ b/src/Components/Topbar/Tobar.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TopBar } from '.';
+
+const meta = {
+  component: TopBar,
+} satisfies Meta<typeof TopBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    children: '스터디원이 남긴 나의 리뷰',
+  },
+} satisfies Story;

--- a/src/Components/Topbar/index.tsx
+++ b/src/Components/Topbar/index.tsx
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+export interface TopBarProps {
+  /** 왼쪽방향 아이콘과 제목 사이의 gap */
+  gap?: number;
+
+  /** Topbar Title content */
+  children?: React.ReactNode;
+}
+
+export const TopBar = ({ gap = 12, children }: TopBarProps) => {
+  return (
+    <TopbarWrapper gap={gap}>
+      <MoveBack onClick={() => {}}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M17.4396 24C17.2348 24 17.03 23.922 16.874 23.7656L6.21997 13.112C5.60677 12.4988 5.60677 11.5012 6.21997 10.8884L16.874 0.234422C17.1864 -0.0779779 17.6928 -0.0779779 18.0052 0.234422C18.3176 0.546822 18.3176 1.05322 18.0052 1.36562L7.37117 12L18.0056 22.6344C18.318 22.9468 18.318 23.4532 18.0056 23.7656C17.8492 23.922 17.6448 24 17.44 24H17.4396Z"
+            fill="black"
+            fill-opacity="0.65"
+          />
+        </svg>
+      </MoveBack>
+      <TopBarTitle>{children}</TopBarTitle>
+    </TopbarWrapper>
+  );
+};
+
+const TopbarWrapper = styled.div<{ gap?: number }>`
+  display: flex;
+  flex: 1 0 0;
+  max-width: 1224px;
+  width: 100%;
+  align-items: center;
+  gap: ${({ gap }) => `${gap}px`};
+`;
+
+const MoveBack = styled.div`
+  display: flex;
+  padding: 8px;
+
+  &:hover {
+    cursor: pointer;
+    svg path {
+      fill-opacity: 0.85;
+    }
+  }
+`;
+
+const TopBarTitle = styled.p`
+  color: ${({ theme }) => theme.color.black5};
+  font-family: 'Pretendard600';
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 32px;
+  flex: 1 0 0;
+`;

--- a/src/Components/Topbar/index.tsx
+++ b/src/Components/Topbar/index.tsx
@@ -22,7 +22,7 @@ export const TopBar = ({ gap = 12, children }: TopBarProps) => {
           />
         </svg>
       </MoveBack>
-      <TopBarTitle>{children}</TopBarTitle>
+      <TopBarContent>{children}</TopBarContent>
     </TopbarWrapper>
   );
 };
@@ -39,6 +39,8 @@ const TopbarWrapper = styled.div<{ gap?: number }>`
 const MoveBack = styled.div`
   display: flex;
   padding: 8px;
+  align-items: flex-end;
+  gap: 10px;
 
   &:hover {
     cursor: pointer;
@@ -48,7 +50,7 @@ const MoveBack = styled.div`
   }
 `;
 
-const TopBarTitle = styled.p`
+const TopBarContent = styled.p`
   color: ${({ theme }) => theme.color.black5};
   font-family: 'Pretendard600';
   font-size: 18px;

--- a/src/Components/Topbar/index.tsx
+++ b/src/Components/Topbar/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 export interface TopBarProps {
@@ -9,9 +10,10 @@ export interface TopBarProps {
 }
 
 export const TopBar = ({ gap = 12, children }: TopBarProps) => {
+  const navigate = useNavigate();
   return (
     <TopbarWrapper gap={gap}>
-      <MoveBack onClick={() => {}}>
+      <MoveBack onClick={() => navigate(-1)}>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
           <path
             d="M17.4396 24C17.2348 24 17.03 23.922 16.874 23.7656L6.21997 13.112C5.60677 12.4988 5.60677 11.5012 6.21997 10.8884L16.874 0.234422C17.1864 -0.0779779 17.6928 -0.0779779 18.0052 0.234422C18.3176 0.546822 18.3176 1.05322 18.0052 1.36562L7.37117 12L18.0056 22.6344C18.318 22.9468 18.318 23.4532 18.0056 23.7656C17.8492 23.922 17.6448 24 17.44 24H17.4396Z"

--- a/src/Components/Topbar/index.tsx
+++ b/src/Components/Topbar/index.tsx
@@ -12,7 +12,7 @@ export interface TopBarProps {
 export const TopBar = ({ gap = 12, children }: TopBarProps) => {
   const navigate = useNavigate();
   return (
-    <TopbarWrapper gap={gap}>
+    <TopbarWrapper $gap={gap}>
       <MoveBack onClick={() => navigate(-1)}>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
           <path
@@ -27,13 +27,13 @@ export const TopBar = ({ gap = 12, children }: TopBarProps) => {
   );
 };
 
-const TopbarWrapper = styled.div<{ gap?: number }>`
+const TopbarWrapper = styled.div<{ $gap?: number }>`
   display: flex;
   flex: 1 0 0;
   max-width: 1224px;
   width: 100%;
   align-items: center;
-  gap: ${({ gap }) => `${gap}px`};
+  gap: ${({ $gap }) => `${$gap}px`};
 `;
 
 const MoveBack = styled.button`

--- a/src/Components/Topbar/index.tsx
+++ b/src/Components/Topbar/index.tsx
@@ -36,7 +36,7 @@ const TopbarWrapper = styled.div<{ gap?: number }>`
   gap: ${({ gap }) => `${gap}px`};
 `;
 
-const MoveBack = styled.div`
+const MoveBack = styled.button`
   display: flex;
   padding: 8px;
   align-items: flex-end;

--- a/src/Mocks/browser.ts
+++ b/src/Mocks/browser.ts
@@ -1,4 +1,4 @@
-// import { setupWorker } from 'msw/browser';
-// import { handlers } from './handlers';
+import { setupWorker } from 'msw/browser';
+import { handlers } from './handlers';
 
-// export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...handlers);


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- [x] 뒤로 가기 버튼 클릭 시, 이전 페이지로 이동하는 기능 구현

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 🛠 뒤로 가기 버튼 클릭 시, 이전 페이지로 이동하는 기능 구현
react-router-dom의 navigate를 이용하여, 뒤로 가기 버튼을 통해 이전 페이지로 이동하도록 구현했습니다.
```tsx
export interface TopBarProps {
  /** 왼쪽방향 아이콘과 제목 사이의 gap */
  gap?: number;

  /** Topbar Title content */
  children?: React.ReactNode;
}

export const TopBar = ({ gap = 12, children }: TopBarProps) => {
  const navigate = useNavigate();
  return (
    <TopbarWrapper gap={gap}>
      <MoveBack onClick={() => navigate(-1)}>
        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
          ....
        </svg>
      </MoveBack>
      <TopBarContent>{children}</TopBarContent>
    </TopbarWrapper>
  );
};
```
 #### 🎬 이전 페이지로 이동
<img width="500" src="https://github.com/Ludo-SMP/ludo-frontend/assets/62270427/008f92fa-b02a-4495-ae2d-783d00582761"/>


#### ✔︎ TopBar 컴포넌트
<img width="250" alt="image" src="https://github.com/Ludo-SMP/ludo-frontend/assets/62270427/3e750815-e10d-4fc4-99e6-e368abebee16">


### 💡 필요한 후속작업이 있어요.
- 스토리북에서 children으로 컴포넌트를 전달하는 방안 고려


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
