### PR TITLE
SP-530 사이드바 컴포넌트 구현

### DIFF
--- a/src/Components/Sidebar/Sidebar.stories.ts
+++ b/src/Components/Sidebar/Sidebar.stories.ts
@@ -17,7 +17,7 @@ export const ActiveProfile: Story = {
     reactRouter: reactRouterParameters({
       routing: [
         {
-          path: '/profile',
+          path: '/mypage',
           useStoryElement: true,
         },
       ],

--- a/src/Components/Sidebar/Sidebar.stories.ts
+++ b/src/Components/Sidebar/Sidebar.stories.ts
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Sidebar } from './Sidebar';
+import { reactRouterParameters } from 'storybook-addon-remix-react-router';
+
+const meta = {
+  component: Sidebar,
+} satisfies Meta<typeof Sidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+
+/** 프로필 설정 탭이 활성화된 상태 */
+export const ActiveProfile: Story = {
+  parameters: {
+    reactRouter: reactRouterParameters({
+      routing: [
+        {
+          path: '/profile',
+          useStoryElement: true,
+        },
+      ],
+    }),
+  },
+};

--- a/src/Components/Sidebar/Sidebar.tsx
+++ b/src/Components/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ export const Sidebar = () => {
   return (
     <Navigation>
       <TabGroup name="개인 정보">
-        <Tab title="프로필 설정" to="/settings" />
+        <Tab title="프로필 설정" to="/profile" />
         <Tab title="스터디원이 남긴 나의 리뷰" to="/review" />
       </TabGroup>
       <TabGroup name="알림 설정">

--- a/src/Components/Sidebar/Sidebar.tsx
+++ b/src/Components/Sidebar/Sidebar.tsx
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+import { Tab } from './Tab';
+import { PropsWithChildren } from 'react';
+
+export const Sidebar = () => {
+  return (
+    <Navigation>
+      <TabGroup name="개인 정보">
+        <Tab title="프로필 설정" to="/settings" />
+        <Tab title="스터디원이 남긴 나의 리뷰" to="/review" />
+      </TabGroup>
+      <TabGroup name="알림 설정">
+        <Tab title="알림 권한 설정" to="/notifications/settings" />
+      </TabGroup>
+      <TabGroup name="알림">
+        <Tab title="루도가 알려요" to="/notifications" />
+      </TabGroup>
+    </Navigation>
+  );
+};
+
+const Navigation = styled.nav`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px 32px;
+  border-radius: 12px;
+  background: ${({ theme }) => theme.color.white};
+`;
+
+const TabGroup = ({ name, children }: PropsWithChildren<{ name: string }>) => {
+  return (
+    <TabGroupInner>
+      <TabGroupInnerText>{name}</TabGroupInnerText>
+      {children}
+    </TabGroupInner>
+  );
+};
+
+const TabGroupInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const TabGroupInnerText = styled.div`
+  align-self: stretch;
+  color: ${({ theme }) => theme.color.black2};
+  font-size: 18px;
+  font-family: Pretendard500;
+  font-weight: 500;
+  line-height: 32px;
+`;

--- a/src/Components/Sidebar/Sidebar.tsx
+++ b/src/Components/Sidebar/Sidebar.tsx
@@ -1,19 +1,22 @@
 import styled from 'styled-components';
 import { Tab } from './Tab';
 import { PropsWithChildren } from 'react';
+import { ROUTES } from '@/Constants/route';
 
 export const Sidebar = () => {
   return (
     <Navigation>
-      <TabGroup name="개인 정보">
-        <Tab title="프로필 설정" to="/profile" />
-        <Tab title="스터디원이 남긴 나의 리뷰" to="/review" />
+      <TabGroup name="회원 정보">
+        <Tab title="회원 정보" to={ROUTES.MYPAGE.HOME} />
+        <Tab title="스터디원이 남긴 나의 리뷰" to={ROUTES.MYPAGE.REVIEWS} />
+        <Tab title="임시 저장된 글" to={ROUTES.MYPAGE.SAVED} />
       </TabGroup>
-      <TabGroup name="알림 설정">
-        <Tab title="알림 권한 설정" to="/notifications/settings" />
+      <TabGroup name="설정">
+        <Tab title="프로필 설정" to={ROUTES.MYPAGE.PROFILE_SETTINGS} />
+        <Tab title="알림 권한 설정" to={ROUTES.MYPAGE.NOTIFICATIONS_SETTINGS} />
       </TabGroup>
       <TabGroup name="알림">
-        <Tab title="루도가 알려요" to="/notifications" />
+        <Tab title="루도가 알려요" to={ROUTES.MYPAGE.NOTIFICATIONS} />
       </TabGroup>
     </Navigation>
   );

--- a/src/Components/Sidebar/Tab.stories.ts
+++ b/src/Components/Sidebar/Tab.stories.ts
@@ -6,7 +6,7 @@ const meta = {
   component: Tab,
   args: {
     title: '프로필 설정',
-    to: '/profile',
+    to: '/mypage/settings/profile',
   },
 } satisfies Meta<typeof Tab>;
 
@@ -21,7 +21,7 @@ export const Active: Story = {
     reactRouter: reactRouterParameters({
       routing: [
         {
-          path: '/profile',
+          path: '/mypage/settings/profile',
           useStoryElement: true,
         },
       ],

--- a/src/Components/Sidebar/Tab.stories.ts
+++ b/src/Components/Sidebar/Tab.stories.ts
@@ -15,6 +15,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {};
 
+/** 현재 페이지에 보여지는 탭일 때 */
 export const Active: Story = {
   parameters: {
     reactRouter: reactRouterParameters({

--- a/src/Components/Sidebar/Tab.stories.ts
+++ b/src/Components/Sidebar/Tab.stories.ts
@@ -1,10 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Tab } from './Tab';
+import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 
 const meta = {
   component: Tab,
   args: {
-    children: '제목',
+    title: '프로필 설정',
+    to: '/profile',
   },
 } satisfies Meta<typeof Tab>;
 
@@ -14,7 +16,14 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {};
 
 export const Active: Story = {
-  args: {
-    $active: true,
+  parameters: {
+    reactRouter: reactRouterParameters({
+      routing: [
+        {
+          path: '/profile',
+          useStoryElement: true,
+        },
+      ],
+    }),
   },
 };

--- a/src/Components/Sidebar/Tab.stories.ts
+++ b/src/Components/Sidebar/Tab.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tab } from './Tab';
+
+const meta = {
+  component: Tab,
+  args: {
+    children: '제목',
+  },
+} satisfies Meta<typeof Tab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+
+export const Active: Story = {
+  args: {
+    $active: true,
+  },
+};

--- a/src/Components/Sidebar/Tab.tsx
+++ b/src/Components/Sidebar/Tab.tsx
@@ -14,13 +14,13 @@ const Box = styled.div<{
   $active: boolean;
 }>`
   color: ${({ theme, $active }) => ($active ? theme.color.purple1 : theme.color.black3)};
-  fontsize: 16;
-  fontfamily: Pretendard600;
-  fontweight: 600;
-  lineheight: 16;
-  wordwrap: break-word;
+  font-size: 16px;
+  font-family: Pretendard600;
+  font-weight: 600;
+  line-height: 16px;
   padding: 16px;
   background: ${({ theme, $active }) => $active && theme.color.purple2};
-  borderradius: 8;
-  justifycontent: center;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
 `;

--- a/src/Components/Sidebar/Tab.tsx
+++ b/src/Components/Sidebar/Tab.tsx
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const Tab = styled.div`
+  color: ${({ theme }) => theme.color.purple1};
+  fontsize: 16;
+  fontfamily: Pretendard600;
+  fontweight: 600;
+  lineheight: 16;
+  wordwrap: break-word;
+  padding: 16px;
+  background: ${({ theme }) => theme.color.purple2};
+  borderradius: 8;
+  justifycontent: center;
+`;

--- a/src/Components/Sidebar/Tab.tsx
+++ b/src/Components/Sidebar/Tab.tsx
@@ -1,6 +1,16 @@
+import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-export const Tab = styled.div<{
+export interface TabProps {
+  title: string;
+  to?: string;
+}
+
+export const Tab = ({ title, to }: TabProps) => {
+  return <NavLink to={to}>{({ isActive }) => <Box $active={isActive}>{title}</Box>}</NavLink>;
+};
+
+const Box = styled.div<{
   $active: boolean;
 }>`
   color: ${({ theme, $active }) => ($active ? theme.color.purple1 : theme.color.black3)};

--- a/src/Components/Sidebar/Tab.tsx
+++ b/src/Components/Sidebar/Tab.tsx
@@ -2,10 +2,14 @@ import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 export interface TabProps {
+  /** 탭 이름 */
   title: string;
+
+  /** 선택되었을 떼 열릴 탭 라우트 */
   to?: string;
 }
 
+/** 사이드바의 여러 탭 중 하나를 표현하는 컴포넌트 */
 export const Tab = ({ title, to }: TabProps) => {
   return <NavLink to={to}>{({ isActive }) => <Box $active={isActive}>{title}</Box>}</NavLink>;
 };

--- a/src/Components/Sidebar/Tab.tsx
+++ b/src/Components/Sidebar/Tab.tsx
@@ -1,14 +1,16 @@
 import styled from 'styled-components';
 
-export const Tab = styled.div`
-  color: ${({ theme }) => theme.color.purple1};
+export const Tab = styled.div<{
+  $active: boolean;
+}>`
+  color: ${({ theme, $active }) => ($active ? theme.color.purple1 : theme.color.black3)};
   fontsize: 16;
   fontfamily: Pretendard600;
   fontweight: 600;
   lineheight: 16;
   wordwrap: break-word;
   padding: 16px;
-  background: ${({ theme }) => theme.color.purple2};
+  background: ${({ theme, $active }) => $active && theme.color.purple2};
   borderradius: 8;
   justifycontent: center;
 `;

--- a/src/Components/Sidebar/Tab.tsx
+++ b/src/Components/Sidebar/Tab.tsx
@@ -27,4 +27,9 @@ const Box = styled.div<{
   border-radius: 8px;
   display: flex;
   align-items: center;
+
+  &:hover {
+    color: ${({ theme }) => theme.color.white};
+    background: ${({ theme }) => theme.color.purple1};
+  }
 `;


### PR DESCRIPTION
![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/e30d76e8-6326-422f-81e4-5569ed2289b4)

### 프리뷰 확인해 보기: https://6639b92a06ad1d3b783f16fd-pqspiznurc.chromatic.com/?path=/docs/components-sidebar--docs

<strong>
Closes #185 
</strong>

### 💡 다음 이슈를 해결했어요.
- 참고: #185
- 마이페이지에 사용될 사이드바 컴포넌트를 구현해 사용자들이 마이페이지를 더욱 쉽게 이동할 수 있도록 하였어요
- 탭을 hover시 스타일을 바꾸어 클릭할 수 있음을 알려주며, 클릭 시 해당 탭으로 이동할 수 있도록 하였어요
<br><br>
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- `<Sidebar />` 컴포넌트를 추가했어요
	- `<Tab />` 컴포넌트를 추가했어요
	- 탭 컴포넌트에 적절한 라우트 경로를 할당했어요.
	- https://github.com/Ludo-SMP/ludo-frontend/blob/408fc09358c4f7055d928a65d268269539997aa4/src/Components/Sidebar/Sidebar.tsx#L8-L21

<br><br>

### 💡 필요한 후속작업이 있어요.
- [x] 임의로 할당한 라우트 전부 `Router/index.tsx` 및 `Constants/route.ts`와 호환되게 바꾸기
<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- https://www.figma.com/file/Sho4QHn0XqEptYBBlbf704/Page-Layout?node-id=3596-31164&mode=dev
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
