### PR TITLE
아코디언 리스트 컴포넌트 구현

### DIFF
--- a/src/Components/Accordion/index.tsx
+++ b/src/Components/Accordion/index.tsx
@@ -56,9 +56,8 @@ const SummaryWrap = styled.div`
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  max-width: 808px;
+  max-width: 912px;
   padding: 16px 0px;
-  gap: 10px;
 `;
 
 const AccordionSummary = styled.div`

--- a/src/Components/AccordionList/AccordionList.stories.tsx
+++ b/src/Components/AccordionList/AccordionList.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AccordionList } from '.';
+import { Accordion } from '../Accordion';
+
+const meta = {
+  component: AccordionList,
+  args: {
+    children: (
+      <Accordion title="스터디 탈퇴 승인 결과가 나왔습니다.">
+        스터디 ‘스터디 이름’에서 팀장에게 요청한 스터디 탈퇴가 승인 되었습니다.
+      </Accordion>
+    ),
+  },
+} satisfies Meta<typeof AccordionList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 아코디언 목록 제목 있는 경우 */
+export const Primary: Story = {
+  args: {
+    ...meta.args,
+    title: '루도가 알려요',
+  },
+};

--- a/src/Components/AccordionList/AccordionList.stories.tsx
+++ b/src/Components/AccordionList/AccordionList.stories.tsx
@@ -19,7 +19,6 @@ type Story = StoryObj<typeof meta>;
 /** 아코디언 목록 제목 있는 경우 */
 export const Primary: Story = {
   args: {
-    ...meta.args,
     title: '루도가 알려요',
   },
 };

--- a/src/Components/AccordionList/index.tsx
+++ b/src/Components/AccordionList/index.tsx
@@ -1,11 +1,11 @@
 import { styled } from 'styled-components';
 
-interface AccordionListProps {
+export interface AccordionListProps {
   /** 아코디언 리스트 제목 */
   title?: string;
 
   /** 제목 아래 들어갈 노드 (ex. 아코디언) */
-  children?: React.ReactNode;
+  children: React.ReactNode;
 }
 
 /** 아코디언 목록 */

--- a/src/Components/AccordionList/index.tsx
+++ b/src/Components/AccordionList/index.tsx
@@ -1,0 +1,48 @@
+import { styled } from 'styled-components';
+
+interface AccordionListProps {
+  /** 아코디언 리스트 제목 */
+  title?: string;
+
+  /** 제목 아래 들어갈 노드 (ex. 아코디언) */
+  children?: React.ReactNode;
+}
+
+/** 아코디언 목록 */
+const AccordionList = ({ title, children }: AccordionListProps) => {
+  return (
+    <Container>
+      <Title>{title ?? '루도가 알려요'}</Title>
+      {children}
+    </Container>
+  );
+};
+
+export { AccordionList };
+
+/** 사용법 */
+//   <AccordionList title="루도가 알려요">
+//     <Stack gap="0px" divider={<Divider width={912} height={3} />}>
+//       {dummy.map((item) => (
+//         <Accordion title={item.title} key={item.id}>
+//           {item.content}
+//         </Accordion>
+//       ))}
+//     </Stack>
+//   </AccordionList>
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 912px;
+  padding: 24px 32px;
+
+  border: 1px solid ${({ theme }) => theme.color.black1};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.color.white};
+`;
+
+/** TODO: 타이포 적용 */
+const Title = styled.h1`
+  margin-bottom: 10px;
+`;

--- a/src/Components/AccordionList/index.tsx
+++ b/src/Components/AccordionList/index.tsx
@@ -20,16 +20,6 @@ const AccordionList = ({ title, children }: AccordionListProps) => {
 
 export { AccordionList };
 
-/** 사용법 */
-//   <AccordionList title="루도가 알려요">
-//     <Stack gap="0px" divider={<Divider width={912} height={3} />}>
-//       {dummy.map((item) => (
-//         <Accordion title={item.title} key={item.id}>
-//           {item.content}
-//         </Accordion>
-//       ))}
-//     </Stack>
-//   </AccordionList>
 
 const Container = styled.div`
   display: flex;

--- a/src/Components/Button/Studies/MaxPeopleButton.tsx
+++ b/src/Components/Button/Studies/MaxPeopleButton.tsx
@@ -23,7 +23,7 @@ const ButtonConTainer = styled.select`
   background-color: ${(props) => props.theme.color.gray1};
   border-radius: 8px;
   border: 1px solid #cbcdd1;
-  background: #f2f3f3;
+  background: ${(props) => props.theme.color.strokeDividerThick};
   color: ${(props) => props.theme.color.gray3};
   padding-left: 16px;
 `;

--- a/src/Components/Button/Studies/StackButton.tsx
+++ b/src/Components/Button/Studies/StackButton.tsx
@@ -31,7 +31,7 @@ const ButtonConTainer = styled.button`
 `;
 
 const StudyText = styled.option`
-  background: #f2f3f3;
+  background: ${({ theme }) => theme.color.strokeDividerThick};
   color: gray;
   text-align: left;
   /* padding-left: 150px; */

--- a/src/Components/Modal/ModalContent/ModalButton/SelectButton.tsx
+++ b/src/Components/Modal/ModalContent/ModalButton/SelectButton.tsx
@@ -21,7 +21,7 @@ const ButtonContainer = styled.button`
   align-items: center;
   gap: 8px;
   border-radius: 8px;
-  background: #f2f3f3;
+  background: ${({ theme }) => theme.color.strokeDividerThick};
 `;
 
 const ButtonText = styled.p`

--- a/src/Components/Selectbox/MaxPeopleButton.tsx
+++ b/src/Components/Selectbox/MaxPeopleButton.tsx
@@ -51,7 +51,7 @@ const ButtonConTainer = styled.select`
   background-color: ${(props) => props.theme.color.gray1};
   border-radius: 8px;
   border: 1px solid #cbcdd1;
-  background: #f2f3f3;
+  background: ${({ theme }) => theme.color.strokeDividerThick};
   color: ${(props) => props.theme.color.gray3};
   padding-left: 16px;
 `;

--- a/src/Pages/CreateRecruitment/page.tsx
+++ b/src/Pages/CreateRecruitment/page.tsx
@@ -309,9 +309,10 @@ export const Box = styled.div<{ display: 'row' | 'column'; gap?: string }>`
     `}
 `;
 
-export const Divider = styled.div`
-  height: 12px;
-  background: #f2f3f3;
+export const Divider = styled.div<{ height?: string | number; width?: string | number }>`
+  height: ${({ height }) => (height ? (typeof height === 'number' ? `${height}px` : `${height}`) : '12px')};
+  background: ${({ theme }) => theme.color.strokeDividerThick};
+  max-width: ${({ width }) => (width ? (typeof width === 'number' ? `${width}px` : `${width}`) : '100%')};
 `;
 
 export const ButtonBox = styled.div`

--- a/src/Pages/Studies/Layout.tsx
+++ b/src/Pages/Studies/Layout.tsx
@@ -267,5 +267,5 @@ const Buttons = styled.div`
 
 const Divider = styled.div`
   height: 12px;
-  background: #f2f3f3;
+  background: ${({ theme }) => theme.color.strokeDividerThick};
 `;

--- a/src/Styles/styled.d.ts
+++ b/src/Styles/styled.d.ts
@@ -32,6 +32,7 @@ declare module 'styled-components' {
       kakao: string;
       kakaoFontColor: string;
       negative: string;
+      strokeDividerThick: string;
     };
 
     font: {

--- a/src/Styles/theme.ts
+++ b/src/Styles/theme.ts
@@ -31,6 +31,7 @@ export const color = {
   kakao: '#FEE500',
   kakaoFontColor: '#521010',
   negative: '#FD3D51',
+  strokeDividerThick: '#F2F3F3',
 };
 
 export const font = {


### PR DESCRIPTION
Closes #188


### 💡 다음 이슈를 해결했어요.
- 아코디언 리스트 컴포넌트 추가했습니다.
- 사용처: 
   - 설정 > 스터디원이 남긴 나의 리뷰
   - 설정 > 알림 

https://github.com/Ludo-SMP/ludo-frontend/assets/71035113/75e95c12-ecf9-4ab1-b3cf-f8eb8d984e8f
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- `<Divider>` 재사용하기 위해 width, height props로 받도록 수정했습니다.

```
    export const Divider = styled.div<{ height?: string | number; width?: string | number }>`
      height: ${({ height }) => (height ? (typeof height === 'number' ? `${height}px` : `${height}`) : '12px')};
      background: ${({ theme }) => theme.color.strokeDividerThick};
      max-width: ${({ width }) => (width ? (typeof width === 'number' ? `${width}px` : `${width}`) : '100%')};
    `;
```


### 💡 필요한 후속작업이 있어요.
- 타이포 브랜치 머지후, title 타이포 적용



### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
