### PR TITLE
SP-535 스터디 진행 그래프 구현

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import { GlobalStyle } from '@/Styles/globalStyles';
 import { withRouter } from 'storybook-addon-remix-react-router';
 import { handlers } from '../src/Mocks/handlers';
 import { initialize, mswLoader } from 'msw-storybook-addon';
+import '../src/App.css';
 
 initialize(
   {

--- a/src/Components/StudyProgress/StudyProgress.stories.tsx
+++ b/src/Components/StudyProgress/StudyProgress.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StudyProgress } from './StudyProgress';
+
+const meta = {
+  component: StudyProgress,
+  args: {
+    totalStudy: 9,
+    completedStudy: 6,
+  },
+  decorators: [
+    (S) => (
+      <div
+        style={{
+          width: 400,
+        }}
+      >
+        <S />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StudyProgress>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/src/Components/StudyProgress/StudyProgress.stories.tsx
+++ b/src/Components/StudyProgress/StudyProgress.stories.tsx
@@ -24,3 +24,17 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {};
+
+export const Newbie: Story = {
+  args: {
+    totalStudy: 0,
+    completedStudy: 0,
+  },
+};
+
+export const Max: Story = {
+  args: {
+    totalStudy: 10,
+    completedStudy: 10,
+  },
+};

--- a/src/Components/StudyProgress/StudyProgress.tsx
+++ b/src/Components/StudyProgress/StudyProgress.tsx
@@ -1,10 +1,14 @@
 import styled from 'styled-components';
 
 export interface StudyProgressProps {
+  /** 진행한 총 스터디 수 */
   totalStudy: number;
+
+  /** 완료한 스터디 수 */
   completedStudy: number;
 }
 
+/** 사용자의 스터디 진행률을 나타내는 컴포넌트 */
 export const StudyProgress = ({ totalStudy, completedStudy }: StudyProgressProps) => {
   const p = (completedStudy / totalStudy) * 100;
 

--- a/src/Components/StudyProgress/StudyProgress.tsx
+++ b/src/Components/StudyProgress/StudyProgress.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const StudyProgress = () => {
+  return <Inner>진행한 4개의 스터디 중 2개 완주!</Inner>;
+};
+
+const Inner = styled.div`
+  font-size: 18px;
+  font-family: Pretendard500;
+  font-weight: 500;
+  line-height: 32px;
+  text-align: center;
+  border: 1px ${({ theme }) => theme.color.black2} solid;
+  border-radius: 9999px;
+  color: white;
+  background-image: linear-gradient(to right, ${({ theme }) => theme.color.purple1} 40%, green 40%);
+`;

--- a/src/Components/StudyProgress/StudyProgress.tsx
+++ b/src/Components/StudyProgress/StudyProgress.tsx
@@ -34,6 +34,7 @@ const Bar = styled.div<{ $ratio: number }>`
 `;
 
 const ClippedText = styled.div<{ $ratio: number }>`
+  flex: 1;
   padding: 0 7px;
   font-size: 18px;
   font-family: Pretendard500;

--- a/src/Components/StudyProgress/StudyProgress.tsx
+++ b/src/Components/StudyProgress/StudyProgress.tsx
@@ -6,27 +6,41 @@ export interface StudyProgressProps {
 }
 
 export const StudyProgress = ({ totalStudy, completedStudy }: StudyProgressProps) => {
-  console.log((completedStudy / totalStudy) * 100);
+  const p = (completedStudy / totalStudy) * 100;
 
   return (
-    <Inner $ratio={(completedStudy / totalStudy) * 100}>
-      진행한 {totalStudy}개의 스터디 중 {completedStudy}개 완주!
-    </Inner>
+    <Bar $ratio={p}>
+      <ClippedText $ratio={p}>
+        진행한 {totalStudy}개의 스터디 중 {completedStudy}개 완주!
+      </ClippedText>
+    </Bar>
   );
 };
 
-const Inner = styled.div<{ $ratio: number }>`
+const Bar = styled.div<{ $ratio: number }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px ${({ theme }) => theme.color.black2} solid;
+  border-radius: 9999px;
+  background-image: linear-gradient(
+    to right,
+    ${({ theme, $ratio }) => `${theme.color.purple1} ${$ratio}%, ${theme.color.gray1} ${$ratio}%`}
+  );
+`;
+
+const ClippedText = styled.div<{ $ratio: number }>`
   padding: 0 7px;
   font-size: 18px;
   font-family: Pretendard500;
   font-weight: 500;
   line-height: 32px;
   text-align: center;
-  border: 1px ${({ theme }) => theme.color.black2} solid;
-  border-radius: 9999px;
-  color: white;
+  background-clip: text;
   background-image: linear-gradient(
     to right,
-    ${({ theme, $ratio }) => `${theme.color.purple1} ${$ratio}%, ${theme.color.gray1} ${$ratio}%`}
+    ${({ theme, $ratio }) => `${theme.color.white} ${$ratio}%, ${theme.color.black2} ${$ratio}%`}
   );
+
+  -webkit-text-fill-color: transparent;
 `;

--- a/src/Components/StudyProgress/StudyProgress.tsx
+++ b/src/Components/StudyProgress/StudyProgress.tsx
@@ -10,7 +10,7 @@ export interface StudyProgressProps {
 
 /** 사용자의 스터디 진행률을 나타내는 컴포넌트 */
 export const StudyProgress = ({ totalStudy, completedStudy }: StudyProgressProps) => {
-  const p = (completedStudy / totalStudy) * 100;
+  const p = totalStudy && (completedStudy / totalStudy) * 100;
 
   return (
     <Bar $ratio={p}>

--- a/src/Components/StudyProgress/StudyProgress.tsx
+++ b/src/Components/StudyProgress/StudyProgress.tsx
@@ -1,10 +1,22 @@
 import styled from 'styled-components';
 
-export const StudyProgress = () => {
-  return <Inner>진행한 4개의 스터디 중 2개 완주!</Inner>;
+export interface StudyProgressProps {
+  totalStudy: number;
+  completedStudy: number;
+}
+
+export const StudyProgress = ({ totalStudy, completedStudy }: StudyProgressProps) => {
+  console.log((completedStudy / totalStudy) * 100);
+
+  return (
+    <Inner $ratio={(completedStudy / totalStudy) * 100}>
+      진행한 {totalStudy}개의 스터디 중 {completedStudy}개 완주!
+    </Inner>
+  );
 };
 
-const Inner = styled.div`
+const Inner = styled.div<{ $ratio: number }>`
+  padding: 0 7px;
   font-size: 18px;
   font-family: Pretendard500;
   font-weight: 500;
@@ -13,5 +25,8 @@ const Inner = styled.div`
   border: 1px ${({ theme }) => theme.color.black2} solid;
   border-radius: 9999px;
   color: white;
-  background-image: linear-gradient(to right, ${({ theme }) => theme.color.purple1} 40%, green 40%);
+  background-image: linear-gradient(
+    to right,
+    ${({ theme, $ratio }) => `${theme.color.purple1} ${$ratio}%, ${theme.color.gray1} ${$ratio}%`}
+  );
 `;


### PR DESCRIPTION
![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/1ec5ce31-3a45-4ac3-95c0-8b3ff2c9b711)

![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/086f36dd-6391-4f1d-91ac-2f66b47463e2)

<strong>
Closes #197
</strong>

### 💡 다음 이슈를 해결했어요.
- 그래디언트를 통해 선형 진행도 컴포넌트를 구현했어요.
- 진행한 스터디 갯수와 완료한 스터디 갯수를 입력받아 비율을 표시해요.
<br><br>
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- (없다면 이 문항을 지워주세요.)
<br><br>

### 💡 필요한 후속작업이 있어요.
- 진행도 0%일 때, 이 사용자가 신규 사용자임을 알려주기.
<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- (없다면 이 문항을 지워주세요.)
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
