### PR TITLE
출석 체크 API 구현

### DIFF
--- a/src/Apis/study.ts
+++ b/src/Apis/study.ts
@@ -30,3 +30,6 @@ export const cancelApply = (studyId: number, recruitmentId: number) =>
 export const deleteStudy = (studyId: number) => httpClient.delete(API_END_POINT.DELETE_STUDY(studyId));
 
 export const leaveStudy = (studyId: number) => httpClient.delete(API_END_POINT.LEAVE_STUDY(studyId));
+
+// 스터디 출석 체크 API
+export const attendStudy = (studyId: number) => httpClient.post(API_END_POINT.ATTEND_STUDY(studyId));

--- a/src/Constants/api.ts
+++ b/src/Constants/api.ts
@@ -29,6 +29,7 @@ export const API_END_POINT = {
   DELETE_STUDY: (studyId: number) => `${API_PREFIX}/studies/${studyId}`,
   LEAVE_STUDY: (studyId: number) => `${API_PREFIX}/studies/${studyId}/participants`,
   APPLICANTS: (studyId: number) => `${API_PREFIX}/studies/${studyId}/applicants`,
+  ATTEND_STUDY: (studyId: number) => `${API_PREFIX}/studies/${studyId}/attendance`,
 
   // APPLY
   APPLY: (studyId: number, recruitmentId: number) =>

--- a/src/Mocks/handlers/study.ts
+++ b/src/Mocks/handlers/study.ts
@@ -196,6 +196,20 @@ const failLeaveStudy = http.delete(`${baseURL}/api/studies/:studyId/participants
     statusText: 'INTERNAL_SERVER_ERROR',
   });
 });
+
+const attendStudy = http.post(`${baseURL}/api/studies/:studyId/attendance`, async () => {
+  return new HttpResponse(
+    JSON.stringify({
+      message: 'success',
+      data: null,
+    }),
+    {
+      status: 200,
+      statusText: 'OK',
+    },
+  );
+});
+
 export default [
   createStudy,
   getStudyDetail,
@@ -212,4 +226,5 @@ export default [
   failDeleteStudy,
   failLeaveStudy,
   leaveStudy,
+  attendStudy,
 ];


### PR DESCRIPTION
<strong>
Closes #209 
</strong>

### 💡 다음 이슈를 해결했어요.
- 매일의 출석 체크 전송시 실행될 API 구현
<br><br>
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- API 엔드포인트에 맞는 상수를 등록했습니다.
  https://github.com/Ludo-SMP/ludo-frontend/blob/cacc384a749c3b69683c62451d096b30dd3d6d90/src/Constants/api.ts#L32
- 사용할 API를 비동기 함수 형태로 구현했습니다.
  https://github.com/Ludo-SMP/ludo-frontend/blob/cacc384a749c3b69683c62451d096b30dd3d6d90/src/Apis/study.ts#L34-L35
- 실제 API를 대신하기 위한 Mock을 작성했습니다.
  https://github.com/Ludo-SMP/ludo-frontend/blob/cacc384a749c3b69683c62451d096b30dd3d6d90/src/Mocks/handlers/study.ts#L200-L211
<br><br>

### 💡 필요한 후속작업이 있어요.
- 스터디 출석 UI 구현
<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- https://studymatchproject.atlassian.net/wiki/spaces/Ludo/pages/63012969
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
