### PR TITLE
SP-567 리뷰 작성 페이지

### DIFF
--- a/src/Components/CustomRadio/CustomRadio.tsx
+++ b/src/Components/CustomRadio/CustomRadio.tsx
@@ -11,7 +11,7 @@ export interface CustomRadioProps {
   size?: number;
 
   /** 선택된 값을 변경하는 handler */
-  setSelectedValue: React.Dispatch<SetStateAction<number | null>>;
+  setSelectedValue: (v: number) => void;
 }
 
 const RADIO_COLOR = { 1: '#F7A477', 2: '#E1A193', 3: '#CB9FAE', 4: '#B59CCA', 5: '#7170BF' };

--- a/src/Components/ReviewQuestion/ReviewQuestion.stories.ts
+++ b/src/Components/ReviewQuestion/ReviewQuestion.stories.ts
@@ -3,22 +3,25 @@ import { ReviewQuestion } from './ReviewQuestion';
 
 const meta = {
   component: ReviewQuestion,
+  args: {
+    title: '1. 이 스터디원은 스터디에 적극적이었나요?',
+    contents: ['아쉬워요.', '적극적이에요.'],
+  },
 } satisfies Meta<typeof ReviewQuestion>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
-  args: {
-    title: '1. 이 스터디원은 스터디에 적극적이었나요?',
-    contents: ['아쉬워요.', '적극적이에요.'],
-  },
-};
+export const Primary: Story = {};
 
 export const MoreTahnFiveOptions: Story = {
   args: {
-    title: '2. 이 스터디원은 본인의 업무에 전문적이있나요?',
-    contents: ['아쉬워요.', '적극적이에요.'],
     optionCnt: 7,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    error: true,
   },
 };

--- a/src/Components/ReviewQuestion/ReviewQuestion.tsx
+++ b/src/Components/ReviewQuestion/ReviewQuestion.tsx
@@ -19,7 +19,7 @@ interface ReviewQuestionProps {
   onChange?: (value: number) => void;
 
   /** 항목이 미완성 상태인지 여부 */
-  error: boolean;
+  error?: boolean;
 }
 
 const errorMessageContent = '해당 항목이 체크되지 않았습니다.';

--- a/src/Components/ReviewQuestion/ReviewQuestion.tsx
+++ b/src/Components/ReviewQuestion/ReviewQuestion.tsx
@@ -11,31 +11,33 @@ interface ReviewQuestionProps {
 
   /** 숫자 선택지 개수 */
   optionCnt?: number;
+
+  /** 선택된 값 */
+  value?: number;
+
+  /** 선택지 변경 시 호출되는 콜백 */
+  onChange?: (value: number) => void;
+
+  /** 항목이 미완성 상태인지 여부 */
+  error: boolean;
 }
 
 const errorMessageContent = '해당 항목이 체크되지 않았습니다.';
 
-export const ReviewQuestion = ({ title, contents, optionCnt = 5 }: ReviewQuestionProps) => {
-  const [selectedValue, setSelectedValue] = useState(null);
-
+export const ReviewQuestion = ({ title, contents, optionCnt = 5, value, onChange, error }: ReviewQuestionProps) => {
   return (
     <ReviewQuestionWrapper>
       <QuestionTitle>{title}</QuestionTitle>
       <SelectSection>
         <QuestionContent alignEnd>{contents[0]}</QuestionContent>
         <RadioButtonsSection>
-          {Array.from({ length: optionCnt }, (_, i) => i + 1).map((value: number) => (
-            <CustomRadio
-              value={value}
-              key={value}
-              setSelectedValue={setSelectedValue}
-              checked={value === selectedValue}
-            />
+          {Array.from({ length: optionCnt }, (_, i) => i + 1).map((i: number) => (
+            <CustomRadio value={i} key={i} setSelectedValue={(v) => onChange?.(v)} checked={i === value} />
           ))}
         </RadioButtonsSection>
         <QuestionContent>{contents[1]}</QuestionContent>
       </SelectSection>
-      <ErrorMessageWrapper>{!selectedValue && errorMessageContent}</ErrorMessageWrapper>
+      <ErrorMessageWrapper>{error && errorMessageContent}</ErrorMessageWrapper>
     </ReviewQuestionWrapper>
   );
 };

--- a/src/Constants/route.ts
+++ b/src/Constants/route.ts
@@ -27,6 +27,6 @@ export const ROUTES = {
     DETAIL: '/studies/:studyId',
     MODIFY: '/studies/:studyId/edit',
     APPLICNATS: '/studies/:studyId/applicants',
-    REVIEW: '/studies/:studyId/:userId/reivew',
+    REVIEW: '/studies/:studyId/:userId/review',
   },
 } as const;

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -1,0 +1,47 @@
+import { Logo } from '@/Assets';
+import styled from 'styled-components';
+
+export const ReviewPage = () => {
+  return (
+    <ReviewPageLayout>
+      <Header>
+        <HeaderInner>
+          <img width="112" src={Logo} alt="Ludo" />
+          <HeaderText>함께했던 스터디원 평가하기</HeaderText>
+        </HeaderInner>
+      </Header>
+    </ReviewPageLayout>
+  );
+};
+
+const ReviewPageLayout = styled.div`
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Header = styled.header`
+  display: flex;
+  padding: 0px 24px;
+  justify-content: center;
+  background: ${({ theme }) => theme.color.white2};
+`;
+
+const HeaderInner = styled.div`
+  width: 1224px;
+  height: 92px;
+  max-width: 1224px;
+  padding: 22px 655px 22px 0px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+`;
+
+const HeaderText = styled.div`
+  color: ${({ theme }) => theme.color.black5};
+  font-family: Pretendard800;
+  font-size: 40px;
+  font-style: normal;
+  font-weight: 800;
+  line-height: 48px;
+`;

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -52,59 +52,63 @@ export const ReviewPage = () => {
 
   return (
     <ReviewPageLayout>
-      <Header>
-        <HeaderInner>
-          <img width="112" src={Logo} alt="Ludo" />
-          <HeaderText>함께했던 스터디원 평가하기</HeaderText>
-        </HeaderInner>
-      </Header>
-      <RowDivider />
-      <Main>
-        <Form onSubmit={handleSubmit(console.log)}>
-          <Member>
-            <MemberTitle>
-              <MemberImage width={32} height={32} />
-              <MemberTitleText>함께한 스터디원</MemberTitleText>
-            </MemberTitle>
-            <MemberProfile>
-              <Profile width={80} height={80} />
-              <MemberProfileBox>
-                <MemberName>닉네임</MemberName>
-                <MemberStudyInfo>
-                  <MemberStudyInfoText>스터디 이름</MemberStudyInfoText>
-                  <ColumnDivider />
-                  <MemberStudyInfoText>포지션</MemberStudyInfoText>
-                </MemberStudyInfo>
-              </MemberProfileBox>
-            </MemberProfile>
-          </Member>
-          <ReviewList>
-            {Object.entries(reviewDataList).map(([key, { title, yes, no }]) => (
-              <li key={key}>
-                <Controller
-                  name={key as keyof typeof reviewDataList}
-                  control={control}
-                  rules={{ required: true }}
-                  render={({ field }) => (
-                    <ReviewQuestion
-                      contents={[no, yes]}
-                      title={title}
-                      error={errors[key as keyof typeof reviewDataList].type === 'required'}
-                      {...field}
-                    />
-                  )}
-                />
-              </li>
-            ))}
-          </ReviewList>
-        </Form>
-      </Main>
-      <Footer>
-        <FooterInner>
-          <Button>나중에 새로 작성하기</Button>
-          <Button scheme="secondary">평가 작성 완료</Button>
-        </FooterInner>
-      </Footer>
+      <form onSubmit={handleSubmit(console.log)}>
+        <Header>
+          <HeaderInner>
+            <img width="112" src={Logo} alt="Ludo" />
+            <HeaderText>함께했던 스터디원 평가하기</HeaderText>
+          </HeaderInner>
+        </Header>
+        <RowDivider />
+        <Main>
+          <MainInner>
+            <Member>
+              <MemberTitle>
+                <MemberImage width={32} height={32} />
+                <MemberTitleText>함께한 스터디원</MemberTitleText>
+              </MemberTitle>
+              <MemberProfile>
+                <Profile width={80} height={80} />
+                <MemberProfileBox>
+                  <MemberName>닉네임</MemberName>
+                  <MemberStudyInfo>
+                    <MemberStudyInfoText>스터디 이름</MemberStudyInfoText>
+                    <ColumnDivider />
+                    <MemberStudyInfoText>포지션</MemberStudyInfoText>
+                  </MemberStudyInfo>
+                </MemberProfileBox>
+              </MemberProfile>
+            </Member>
+            <ReviewList>
+              {Object.entries(reviewDataList).map(([key, { title, yes, no }]) => (
+                <li key={key}>
+                  <Controller
+                    name={key as keyof typeof reviewDataList}
+                    control={control}
+                    rules={{ required: true }}
+                    render={({ field }) => (
+                      <ReviewQuestion
+                        contents={[no, yes]}
+                        title={title}
+                        error={errors[key as keyof typeof reviewDataList]?.type === 'required'}
+                        {...field}
+                      />
+                    )}
+                  />
+                </li>
+              ))}
+            </ReviewList>
+          </MainInner>
+        </Main>
+        <Footer>
+          <FooterInner>
+            <Button>나중에 새로 작성하기</Button>
+            <Button type="submit" scheme="secondary">
+              평가 작성 완료
+            </Button>
+          </FooterInner>
+        </Footer>
+      </form>
     </ReviewPageLayout>
   );
 };
@@ -148,7 +152,7 @@ const Main = styled.main`
   background: ${({ theme }) => theme.color.gray1};
 `;
 
-const Form = styled.form`
+const MainInner = styled.form`
   flex: 1;
   padding: 40px 0px;
   max-width: 808px;

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -1,7 +1,9 @@
-import { Logo } from '@/Assets';
+import { Logo, Profile } from '@/Assets';
 import Button from '@/Components/Common/Button';
 import { RowDivider } from '@/Components/Common/Divider/RowDivider';
 import styled from 'styled-components';
+import { MemberImage } from '@/Assets';
+import { ColumnDivider } from '@/Components/Common/Divider/ColumnDivider';
 
 export const ReviewPage = () => {
   return (
@@ -15,7 +17,23 @@ export const ReviewPage = () => {
       <RowDivider />
       <Main>
         <MainInner>
-          <Member></Member>
+          <Member>
+            <MemberTitle>
+              <MemberImage width={32} height={32} />
+              <MemberTitleText>함께한 스터디원</MemberTitleText>
+            </MemberTitle>
+            <MemberProfile>
+              <Profile width={80} height={80} />
+              <MemberProfileBox>
+                <MemberName>닉네임</MemberName>
+                <MemberStudyInfo>
+                  <MemberStudyInfoText>스터디 이름</MemberStudyInfoText>
+                  <ColumnDivider />
+                  <MemberStudyInfoText>포지션</MemberStudyInfoText>
+                </MemberStudyInfo>
+              </MemberProfileBox>
+            </MemberProfile>
+          </Member>
         </MainInner>
       </Main>
       <Footer>
@@ -79,6 +97,61 @@ const Member = styled.div`
   display: flex;
   flex-direction: column;
   gap: 24px;
+`;
+
+const MemberTitle = styled.h2`
+  display: flex;
+  min-width: 300px;
+  max-width: 1224px;
+  align-items: center;
+  gap: 8px;
+`;
+
+const MemberTitleText = styled.h2`
+  color: ${({ theme }) => theme.color.black5};
+  font-family: Pretendard600;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 32px;
+`;
+
+const MemberProfile = styled.div`
+  display: flex;
+  min-width: 300px;
+  max-width: 808px;
+  align-items: center;
+  gap: 24px;
+`;
+
+const MemberProfileBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const MemberName = styled.span`
+  color: ${({ theme }) => theme.color.black5};
+  font-family: Pretendard600;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 32px;
+`;
+
+const MemberStudyInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const MemberStudyInfoText = styled.span`
+  color: ${({ theme }) => theme.color.black2};
+  font-family: Pretendard400;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 24px;
 `;
 
 // 실제로는 의미적 푸터가 아닌 레이아웃상 하단을 의미

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -4,6 +4,41 @@ import { RowDivider } from '@/Components/Common/Divider/RowDivider';
 import styled from 'styled-components';
 import { MemberImage } from '@/Assets';
 import { ColumnDivider } from '@/Components/Common/Divider/ColumnDivider';
+import { ReviewQuestion } from '@/Components/ReviewQuestion/ReviewQuestion';
+
+interface ReviewData {
+  title: string;
+  yes: string;
+  no: string;
+}
+
+const reviewDataList = [
+  {
+    title: '이 스터디원은 스터디에 적극적이었나요?',
+    yes: '적극적이예요.',
+    no: '아쉬워요.',
+  },
+  {
+    title: '이 스터디원은 본인의 업무에 전문적이있나요?',
+    yes: '전문적이예요.',
+    no: '아쉬워요.',
+  },
+  {
+    title: '이 스터디원은 다른 팀원들과 의사 소통을 잘했나요?',
+    yes: '잘했어요.',
+    no: '아쉬워요.',
+  },
+  {
+    title: '이 스터디원과 스터디를 다시 함께 할 의향이 있나요?',
+    yes: '함께하고 싶어요.',
+    no: '그렇지는 않아요.',
+  },
+  {
+    title: '이 스터디원을 주변 사람에게 추천하나요?',
+    yes: '추천하고 싶어요.',
+    no: '그렇지는 않아요.',
+  },
+] satisfies Array<ReviewData>;
 
 export const ReviewPage = () => {
   return (
@@ -34,6 +69,13 @@ export const ReviewPage = () => {
               </MemberProfileBox>
             </MemberProfile>
           </Member>
+          <ReviewList>
+            {reviewDataList.map(({ title, yes, no }) => (
+              <li>
+                <ReviewQuestion contents={[no, yes]} title={title} />
+              </li>
+            ))}
+          </ReviewList>
         </MainInner>
       </Main>
       <Footer>
@@ -152,6 +194,18 @@ const MemberStudyInfoText = styled.span`
   font-style: normal;
   font-weight: 400;
   line-height: 24px;
+`;
+
+const ReviewList = styled.ul`
+  min-width: 348px;
+  max-width: 808px;
+  padding: 40px 32px;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  border-radius: ${({ theme }) => theme.borderRadius.cornerRadius12};
+  background: ${({ theme }) => theme.color.white2};
 `;
 
 // 실제로는 의미적 푸터가 아닌 레이아웃상 하단을 의미

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -1,4 +1,5 @@
 import { Logo } from '@/Assets';
+import Button from '@/Components/Common/Button';
 import { RowDivider } from '@/Components/Common/Divider/RowDivider';
 import styled from 'styled-components';
 
@@ -12,6 +13,12 @@ export const ReviewPage = () => {
         </HeaderInner>
       </Header>
       <RowDivider />
+      <Footer>
+        <FooterInner>
+          <Button>나중에 새로 작성하기</Button>
+          <Button>평가 작성 완료</Button>
+        </FooterInner>
+      </Footer>
     </ReviewPageLayout>
   );
 };
@@ -46,4 +53,21 @@ const HeaderText = styled.div`
   font-style: normal;
   font-weight: 800;
   line-height: 48px;
+`;
+
+// 실제로는 의미적 푸터가 아닌 레이아웃상 하단을 의미
+const Footer = styled.div`
+  display: flex;
+  padding: 0px 24px;
+  justify-content: center;
+  background: ${({ theme }) => theme.color.gray1};
+`;
+
+const FooterInner = styled.div`
+  display: flex;
+  max-width: 808px;
+  padding: 24px 0px 40px 0px;
+  justify-content: center;
+  gap: 24px;
+  background: ${({ theme }) => theme.color.gray1};
 `;

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -124,9 +124,11 @@ const Main = styled.main`
   padding: 0px 24px;
   display: flex;
   justify-content: center;
+  background: ${({ theme }) => theme.color.gray1};
 `;
 
 const MainInner = styled.div`
+  flex: 1;
   padding: 40px 0px;
   max-width: 808px;
   display: flex;
@@ -200,7 +202,6 @@ const ReviewList = styled.ul`
   min-width: 348px;
   max-width: 808px;
   padding: 40px 32px;
-  align-items: center;
   display: flex;
   flex-direction: column;
   gap: 32px;
@@ -210,17 +211,22 @@ const ReviewList = styled.ul`
 
 // 실제로는 의미적 푸터가 아닌 레이아웃상 하단을 의미
 const Footer = styled.div`
-  display: flex;
   padding: 0px 24px;
+  display: flex;
   justify-content: center;
   background: ${({ theme }) => theme.color.gray1};
 `;
 
 const FooterInner = styled.div`
+  flex: 1;
   display: flex;
   max-width: 808px;
   padding: 24px 0px 40px 0px;
   justify-content: center;
   gap: 24px;
   background: ${({ theme }) => theme.color.gray1};
+
+  & > button {
+    flex: 1;
+  }
 `;

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -81,7 +81,7 @@ export const ReviewPage = () => {
       <Footer>
         <FooterInner>
           <Button>나중에 새로 작성하기</Button>
-          <Button>평가 작성 완료</Button>
+          <Button scheme="secondary">평가 작성 완료</Button>
         </FooterInner>
       </Footer>
     </ReviewPageLayout>

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -1,4 +1,5 @@
 import { Logo } from '@/Assets';
+import { RowDivider } from '@/Components/Common/Divider/RowDivider';
 import styled from 'styled-components';
 
 export const ReviewPage = () => {
@@ -10,6 +11,7 @@ export const ReviewPage = () => {
           <HeaderText>함께했던 스터디원 평가하기</HeaderText>
         </HeaderInner>
       </Header>
+      <RowDivider />
     </ReviewPageLayout>
   );
 };

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -152,7 +152,7 @@ const Main = styled.main`
   background: ${({ theme }) => theme.color.gray1};
 `;
 
-const MainInner = styled.form`
+const MainInner = styled.div`
   flex: 1;
   padding: 40px 0px;
   max-width: 808px;

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -13,6 +13,11 @@ export const ReviewPage = () => {
         </HeaderInner>
       </Header>
       <RowDivider />
+      <Main>
+        <MainInner>
+          <Member></Member>
+        </MainInner>
+      </Main>
       <Footer>
         <FooterInner>
           <Button>나중에 새로 작성하기</Button>
@@ -53,6 +58,27 @@ const HeaderText = styled.div`
   font-style: normal;
   font-weight: 800;
   line-height: 48px;
+`;
+
+const Main = styled.main`
+  padding: 0px 24px;
+  display: flex;
+  justify-content: center;
+`;
+
+const MainInner = styled.div`
+  padding: 40px 0px;
+  max-width: 808px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;
+
+const Member = styled.div`
+  max-width: 808px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 `;
 
 // 실제로는 의미적 푸터가 아닌 레이아웃상 하단을 의미

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { MemberImage } from '@/Assets';
 import { ColumnDivider } from '@/Components/Common/Divider/ColumnDivider';
 import { ReviewQuestion } from '@/Components/ReviewQuestion/ReviewQuestion';
+import { useForm } from 'react-hook-form';
 
 interface ReviewData {
   title: string;
@@ -12,35 +13,39 @@ interface ReviewData {
   no: string;
 }
 
-const reviewDataList = [
-  {
+const reviewDataList = {
+  activenessScore: {
     title: '이 스터디원은 스터디에 적극적이었나요?',
     yes: '적극적이예요.',
     no: '아쉬워요.',
   },
-  {
+  professionalismScore: {
     title: '이 스터디원은 본인의 업무에 전문적이있나요?',
     yes: '전문적이예요.',
     no: '아쉬워요.',
   },
-  {
+  communicationScore: {
     title: '이 스터디원은 다른 팀원들과 의사 소통을 잘했나요?',
     yes: '잘했어요.',
     no: '아쉬워요.',
   },
-  {
+  togetherScore: {
     title: '이 스터디원과 스터디를 다시 함께 할 의향이 있나요?',
     yes: '함께하고 싶어요.',
     no: '그렇지는 않아요.',
   },
-  {
+  recommendScore: {
     title: '이 스터디원을 주변 사람에게 추천하나요?',
     yes: '추천하고 싶어요.',
     no: '그렇지는 않아요.',
   },
-] satisfies Array<ReviewData>;
+};
+
+type ReviewResult = Record<keyof typeof reviewDataList, number>;
 
 export const ReviewPage = () => {
+  const { register } = useForm<ReviewResult>();
+
   return (
     <ReviewPageLayout>
       <Header>
@@ -51,7 +56,7 @@ export const ReviewPage = () => {
       </Header>
       <RowDivider />
       <Main>
-        <MainInner>
+        <Form onSubmit={console.log}>
           <Member>
             <MemberTitle>
               <MemberImage width={32} height={32} />
@@ -70,13 +75,13 @@ export const ReviewPage = () => {
             </MemberProfile>
           </Member>
           <ReviewList>
-            {reviewDataList.map(({ title, yes, no }) => (
-              <li>
-                <ReviewQuestion contents={[no, yes]} title={title} />
+            {Object.entries(reviewDataList).map(([key, { title, yes, no }]) => (
+              <li key={key}>
+                <ReviewQuestion contents={[no, yes]} title={title} {...register(key)} />
               </li>
             ))}
           </ReviewList>
-        </MainInner>
+        </Form>
       </Main>
       <Footer>
         <FooterInner>
@@ -127,7 +132,7 @@ const Main = styled.main`
   background: ${({ theme }) => theme.color.gray1};
 `;
 
-const MainInner = styled.div`
+const Form = styled.form`
   flex: 1;
   padding: 40px 0px;
   max-width: 808px;

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { MemberImage } from '@/Assets';
 import { ColumnDivider } from '@/Components/Common/Divider/ColumnDivider';
 import { ReviewQuestion } from '@/Components/ReviewQuestion/ReviewQuestion';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 
 interface ReviewData {
   title: string;
@@ -44,7 +44,11 @@ const reviewDataList = {
 type ReviewResult = Record<keyof typeof reviewDataList, number>;
 
 export const ReviewPage = () => {
-  const { register } = useForm<ReviewResult>();
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+  } = useForm<ReviewResult>();
 
   return (
     <ReviewPageLayout>
@@ -56,7 +60,7 @@ export const ReviewPage = () => {
       </Header>
       <RowDivider />
       <Main>
-        <Form onSubmit={console.log}>
+        <Form onSubmit={handleSubmit(console.log)}>
           <Member>
             <MemberTitle>
               <MemberImage width={32} height={32} />
@@ -77,7 +81,19 @@ export const ReviewPage = () => {
           <ReviewList>
             {Object.entries(reviewDataList).map(([key, { title, yes, no }]) => (
               <li key={key}>
-                <ReviewQuestion contents={[no, yes]} title={title} {...register(key)} />
+                <Controller
+                  name={key as keyof typeof reviewDataList}
+                  control={control}
+                  rules={{ required: true }}
+                  render={({ field }) => (
+                    <ReviewQuestion
+                      contents={[no, yes]}
+                      title={title}
+                      error={errors[key as keyof typeof reviewDataList].type === 'required'}
+                      {...field}
+                    />
+                  )}
+                />
               </li>
             ))}
           </ReviewList>

--- a/src/Router/index.tsx
+++ b/src/Router/index.tsx
@@ -19,6 +19,7 @@ import { EditRecruitmentFetcher } from '@/Pages/EditRecruitment/EditRecruitmentF
 import { MyPageLayout } from '@/Layout/MyPageLayout';
 import { SettingLayout } from '@/Layout/SettingLayout';
 import { Notifications } from '@/Pages/Notifications';
+import { ReviewPage } from '@/Pages/Review';
 
 export const RouterPath = createBrowserRouter([
   {
@@ -136,7 +137,7 @@ export const RouterPath = createBrowserRouter([
       {
         // 스터디원 평가 페이지
         path: ROUTES.STUDY.REVIEW,
-        element: <>TODO</>,
+        element: <ReviewPage />,
       },
       {
         path: ROUTES.RECRUITMENT.EDIT,

--- a/src/Router/index.tsx
+++ b/src/Router/index.tsx
@@ -135,14 +135,14 @@ export const RouterPath = createBrowserRouter([
         element: <ApplicantsPage />,
       },
       {
-        // 스터디원 평가 페이지
-        path: ROUTES.STUDY.REVIEW,
-        element: <ReviewPage />,
-      },
-      {
         path: ROUTES.RECRUITMENT.EDIT,
         element: <EditRecruitmentFetcher />,
       },
     ],
+  },
+  {
+    // 스터디원 평가 페이지
+    path: ROUTES.STUDY.REVIEW,
+    element: <ReviewPage />,
   },
 ]);


### PR DESCRIPTION
![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/d6fdafa0-d207-4cfd-9243-ba64130f3488)

<strong>
Closes #225

Closes #205
</strong>

### 💡 다음 이슈를 해결했어요.
- 두 가지 이슈를 동시에 해결합니다. (분리하기 힘들어서 하나로 병합)
	- 리뷰 페이지 구현 #225
	- 리뷰 평가 폼 검증 로직 구현 #205
<br><br>
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- https://github.com/Ludo-SMP/ludo-frontend/blob/6bad78565a1d399269608639a758aa8d4a2b7a81/src/Constants/route.ts#L30
  `reivew` 오타를 `review`로 수정 ~~이거때문에 한시간 날림~~
- https://github.com/Ludo-SMP/ludo-frontend/blob/6bad78565a1d399269608639a758aa8d4a2b7a81/src/Router/index.tsx#L143-L147
  리뷰 페이지는 독립적인 레이아웃을 가지므로 메인 레이아웃의 `<Outlet />`으로 들어가지 않도록 바깥으로 이동.
- https://github.com/Ludo-SMP/ludo-frontend/blob/6bad78565a1d399269608639a758aa8d4a2b7a81/src/Components/ReviewQuestion/ReviewQuestion.tsx#L15-L22
  `ReviewQuestion` 컴포넌트를 RHF에서 control 할 수 있도록 `value`, `onChange`, `error` 등의 prop들을 추가.
- https://github.com/Ludo-SMP/ludo-frontend/blob/6bad78565a1d399269608639a758aa8d4a2b7a81/src/Components/CustomRadio/CustomRadio.tsx#L13-L14
  `CustomRadio` 컴포넌트의 콜백의 타입을 setState 함수뿐만 아니라 타 콜백도 사용할 수 있도록 확장
- https://github.com/Ludo-SMP/ludo-frontend/blob/6bad78565a1d399269608639a758aa8d4a2b7a81/src/Components/ReviewQuestion/ReviewQuestion.stories.ts#L23-L27
  `ReviewQuestion` 컴포넌트의 `error` prop 사용법에 대한 스토리 추가
- https://github.com/Ludo-SMP/ludo-frontend/blob/6bad78565a1d399269608639a758aa8d4a2b7a81/src/Pages/Review/index.tsx#L82-L100
  각 리뷰 항목을 RHF에서 컨트롤, 값이 미기재시 에러 메세지 표시.
<br><br>

### 💡 필요한 후속작업이 있어요.
- API mutation 바인딩
- router `useParams` 훅을 사용한 리뷰어 데이터 query 로직
<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- https://www.figma.com/design/Sho4QHn0XqEptYBBlbf704/Page-Layout?node-id=3595-19443&m=dev
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
