### PR TITLE
chore: 로그인 에러 관련 useSSE 훅 임시 주석 처리

### DIFF
--- a/src/Components/Header/AlarmBell/index.tsx
+++ b/src/Components/Header/AlarmBell/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { AlarmInbox } from '@/Components/AlarmInBox';
 import { useNotifications } from '@/Hooks/notifications/useNotifications';
-import { useSSE } from '@/Hooks/useSSE';
+// import { useSSE } from '@/Hooks/useSSE';
 import styled from 'styled-components';
 import { flexCenter } from '@/Styles/theme';
 import { Alarm } from '@/Assets';
@@ -12,14 +12,14 @@ const AlarmBell = () => {
 
   const { data } = useNotifications();
 
-  const { fetchSSE, eventSource } = useSSE();
+  //const { fetchSSE, eventSource } = useSSE();
 
   useEffect(() => {
     // 커넥션 종료되면 자동으로 onerror 호출 후, 커넥션 다시 맺는 것 방지하기 위해 주석 처리
-    fetchSSE();
+    //fetchSSE();
 
     return () => {
-      eventSource.current.close();
+      // eventSource.current.close();
     };
   }, []);
 


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 구글로그인 리다이렉트 에러 관련 useSSE 훅 임시 주석 처리했습니다.
<br><br>

에러 메시지 전문
```
{
  "ok": false,
  "message": "Unable to acquire JDBC Connection [HikariPool-1 - Connection is not available, request timed out after 30000ms.] [n/a]",
  "data": null
}
```


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
