### PR TITLE
chore: 배포 도메인 401 로직 확인

### DIFF
--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,4 +1,4 @@
-// import { logOut } from '@/Apis/auth';
+import { logOut } from '@/Apis/auth';
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 
 export const createClient = (config?: AxiosRequestConfig) => {
@@ -20,18 +20,20 @@ export const createClient = (config?: AxiosRequestConfig) => {
       return response;
     },
     async (error: AxiosError) => {
-      // if (error.response?.status === 400) {
-      //   console.log(error.response.data);
-      // }
+      console.log('axios response', error, error.response, error.response?.status);
 
-      // // 토큰이 만료된 경우
-      // else if (error.response?.status === 401) {
-      //   console.log(error.response);
-      //   try {
-      //     //const data = await logOut(); // 로그아웃 통해 쿠키 제거
-      //     //if (data) window.location.href = '/';
-      //   } catch {}
-      // }
+      if (error.response?.status === 400) {
+        console.log('400', error.response);
+      }
+
+      // 토큰이 만료된 경우
+      else if (error.response?.status === 401) {
+        console.log('401', error.response);
+        try {
+          const data = await logOut();
+          if (data) window.location.href = '/';
+        } catch {}
+      }
       // Login Provider에서 에러 핸들링하도록 reject
       return Promise.reject(error);
     },


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 로컬 환경에서 로그인 한 경우, cors error 발생 후, 400 로직을 거치지 않는 문제 발생 -> 배포 도메인에서 테스트 시도
<br><br>
<img width="600" alt="image" src="https://github.com/Ludo-SMP/ludo-frontend/assets/71035113/9c03b82e-a12c-4ea3-8c00-3f9088d004af">

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
