### PR TITLE
fix: 루도가 알려요 > notification undefined 예외 처리

### DIFF
--- a/src/Pages/Notifications/index.tsx
+++ b/src/Pages/Notifications/index.tsx
@@ -39,12 +39,12 @@ export const Notifications = () => {
         ) : (
           <Stack divider={<Divider height={2} $dividerColor="#e5e6e8" />} gap={'0px'}>
             {data?.notification
-              .filter((notification: NotificationSSEType) => {
+              ?.filter((notification: NotificationSSEType) => {
                 if (selectedNotificationType === 'STUDY')
                   return !notification.type.includes('REVIEW') && !notification.type.includes('RECRUITMENT');
                 return notification.type.includes(selectedNotificationType);
               })
-              .map((notification: NotificationSSEType) => (
+              ?.map((notification: NotificationSSEType) => (
                 <Notification {...notification} key={notification.notificationId} />
               ))}
           </Stack>


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 루도가 알려요 페이지에서 notification이 undefined일 경우를 대비해, 옵셔널 체이닝을 추가했습니다.

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
