### PR TITLE
hotfix: 스터디 상태 페이지 > study undefined 예외 처리

### DIFF
--- a/src/Pages/StudyDetail/index.tsx
+++ b/src/Pages/StudyDetail/index.tsx
@@ -42,7 +42,9 @@ export const StudyDetailPage = () => {
 
   if (isLoading) return <Loading />;
 
-  const didIAttendToday = isToday(new Date(study.participants.find(({ id }) => id === user?.id)?.recentAttendanceDate));
+  const didIAttendToday = isToday(
+    new Date(study.participants?.find(({ id }) => id === user?.id)?.recentAttendanceDate),
+  );
 
   return (
     <Grid>
@@ -113,7 +115,7 @@ export const StudyDetailPage = () => {
             <RowDivider />
             <Members>
               <MembersCountBar>
-                <MemberCounts count={study.participants.length} />
+                <MemberCounts count={study.participants?.length} />
                 {isOwner && (
                   <ApplicationButton>
                     <Link to={'#'}>스터디원 모집</Link>

--- a/src/Pages/StudyDetail/index.tsx
+++ b/src/Pages/StudyDetail/index.tsx
@@ -43,20 +43,20 @@ export const StudyDetailPage = () => {
   if (isLoading) return <Loading />;
 
   const didIAttendToday = isToday(
-    new Date(study.participants?.find(({ id }) => id === user?.id)?.recentAttendanceDate),
+    new Date(study?.participants?.find(({ id }) => id === user?.id)?.recentAttendanceDate),
   );
 
   return (
     <Grid>
       <StudyDetailLayout>
-        <ParentNav studyTitle={study.title} status={study.status} />
+        <ParentNav studyTitle={study?.title} status={study?.status} />
         <Main>
           <Sidebar
-            id={study.id}
-            category={study.category.name}
-            startDateTime={study.startDateTime}
-            endDateTime={study.endDateTime}
-            way={study.way}
+            id={study?.id}
+            category={study?.category.name}
+            startDateTime={study?.startDateTime}
+            endDateTime={study?.endDateTime}
+            way={study?.way}
             isOwner={isOwner}
           />
           <MainSection>
@@ -103,7 +103,7 @@ export const StudyDetailPage = () => {
                       textDecoration: 'underline',
                     }}
                   >
-                    {study.platform}
+                    {study?.platform}
                   </a>
                 </TopBarSectionText>
               </PlatformSection>
@@ -115,7 +115,7 @@ export const StudyDetailPage = () => {
             <RowDivider />
             <Members>
               <MembersCountBar>
-                <MemberCounts count={study.participants?.length} />
+                <MemberCounts count={study?.participants?.length} />
                 {isOwner && (
                   <ApplicationButton>
                     <Link to={'#'}>스터디원 모집</Link>
@@ -123,7 +123,7 @@ export const StudyDetailPage = () => {
                 )}
               </MembersCountBar>
               <MemberList>
-                <MemberSection members={study.participants} />
+                <MemberSection members={study?.participants} />
               </MemberList>
             </Members>
           </MainSection>


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 스터디 생성 후, 스터디 상태 페이지 진입 시 스터디 상태 API에서 500 에러가 발생하고 있음.
- optional chaining 으로 study가 undefined 일 경우 예외 처리 로직 추가

에러 메시지 전문
```
{
    "ok": false,
    "message": "could not initialize proxy [com.ludo.study.studymatchingplatform.study.domain.study.category.Category#1] - no Session",
    "data": null
}
```

### 💡 필요한 후속작업이 있어요.
- API response 에서 ok 가 true 일 경우에만 data에 접근하는 방어 로직 추가

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
