### PR TITLE
SP-486 실시간 알림 갱신 로직 수정

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn test
 yarn lint-staged

--- a/src/Components/AlarmInBox/index.tsx
+++ b/src/Components/AlarmInBox/index.tsx
@@ -13,23 +13,19 @@ import { useReadNotification } from '@/Hooks/notifications/useReadNotification';
 
 export interface AlarmInboxProps {
   handleOpen?: (prev: boolean) => void;
-  alarmPreviews?: {
-    notification: NotificationSSEType[];
-  };
+  alarmPreviews?: NotificationSSEType[];
 }
 
 export const AlarmInbox = ({ alarmPreviews, handleOpen }: AlarmInboxProps) => {
-  const { notification } = alarmPreviews ?? {};
-
   const inboxRef = useRef<HTMLDivElement>(null);
 
   useOutSideClick(inboxRef, () => {
     handleOpen && handleOpen(false);
   });
 
-  const notReadAlarm = notification?.filter((alarm) => !alarm.read);
+  const notReadAlarm = alarmPreviews?.filter((alarm) => !alarm?.read);
   const isReadAll = () => notReadAlarm?.length === 0;
-  const { mutate } = useReadNotification([...(notReadAlarm ?? []).map((alarm) => alarm.notificationId)]);
+  const { mutate } = useReadNotification([...(notReadAlarm ?? []).map((alarm) => alarm?.notificationId)]);
 
   return (
     <AlarmInboxBox ref={inboxRef}>
@@ -47,8 +43,8 @@ export const AlarmInbox = ({ alarmPreviews, handleOpen }: AlarmInboxProps) => {
         </TopBar>
         {/* 페이지 이동 후 알림 인박스 닫기 */}
         <AlarmList onClick={() => handleOpen(false)}>
-          {notification
-            ?.filter((alarm: NotificationSSEType) => !alarm.read)
+          {alarmPreviews
+            ?.filter((alarm: NotificationSSEType) => !alarm?.read)
             ?.map((alarm) => <AlarmPreview key={`${alarm?.notificationId}`} {...alarm} />)}
         </AlarmList>
         <RowDivider rowHeight={1} />

--- a/src/Components/Header/AlarmBell/index.tsx
+++ b/src/Components/Header/AlarmBell/index.tsx
@@ -15,7 +15,6 @@ const AlarmBell = () => {
   const { fetchSSE, eventSource } = useSSE();
 
   useEffect(() => {
-    // 커넥션 종료되면 자동으로 onerror 호출 후, 커넥션 다시 맺는 것 방지하기 위해 주석 처리
     fetchSSE();
 
     return () => {
@@ -30,7 +29,7 @@ const AlarmBell = () => {
       <AlarmSection onClick={() => setIsOpen((prev) => !prev)}>
         <Alarm width={40} height={40} />
         <AlarmCnt>
-          <Inner>{data?.notification?.filter((alarm) => !alarm.read).length ?? 0}</Inner>
+          <Inner>{data?.filter((alarm) => !alarm?.read)?.length ?? 0}</Inner>
         </AlarmCnt>
       </AlarmSection>
       {isOpen && <AlarmInbox alarmPreviews={data} handleOpen={handleOpen} />}

--- a/src/Hooks/notifications/useNotifications.ts
+++ b/src/Hooks/notifications/useNotifications.ts
@@ -11,7 +11,7 @@ export const useNotifications = () => {
   return useQuery({
     queryKey: [...NOTIFICATIONS.NOTIFICATIONS],
     queryFn: () => getNotifications(),
-    select: (data: { data: { data: NotificationResponse } }) => data?.data?.data,
+    select: (data: { data: { data: NotificationSSEType[] } }) => data?.data?.data,
     staleTime: 60 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
   });

--- a/src/Hooks/useSSE.ts
+++ b/src/Hooks/useSSE.ts
@@ -3,7 +3,6 @@ import { EventSourcePolyfill, Event, MessageEvent } from 'event-source-polyfill'
 import { NOTIFICATIONS } from '@/Constants/queryString';
 import { useQueryClient } from '@tanstack/react-query';
 import { NotificationSSEType } from '@/Types/notifications';
-import { NotificationResponse } from './notifications/useNotifications';
 
 /**
  * SSE 구독 후, 실시간 알림 데이터를 받아오는 훅
@@ -27,11 +26,11 @@ export const useSSE = () => {
     // 메시지 수신 시 캐시에 저장 - 이름을 따로 설정한 경우, 이벤트 리스너 부착
     eventSource.current.addEventListener('notification', (evt: Event) => {
       const messageEvent = evt as MessageEvent;
-      const data: { data: NotificationSSEType } = JSON.parse(messageEvent.data);
+      const data = JSON.parse(messageEvent.data);
 
-      queryClient.setQueryData(NOTIFICATIONS.NOTIFICATIONS, (prev: { data: { data: NotificationResponse } }) => {
+      queryClient.setQueryData(NOTIFICATIONS.NOTIFICATIONS, (prev: { data: { data: NotificationSSEType[] } }) => {
         const newData = JSON.parse(JSON.stringify(prev));
-        newData.data.data.notification = [...prev?.data?.data?.notification, data?.data];
+        newData.data.data = [...(prev?.data?.data ?? []), data];
         return newData;
       });
     });

--- a/src/Pages/Notifications/index.tsx
+++ b/src/Pages/Notifications/index.tsx
@@ -38,7 +38,7 @@ export const Notifications = () => {
           <Loading />
         ) : (
           <Stack divider={<Divider height={2} $dividerColor="#e5e6e8" />} gap={'0px'}>
-            {data?.notification
+            {data
               ?.filter((notification: NotificationSSEType) => {
                 if (selectedNotificationType === 'STUDY')
                   return !notification.type.includes('REVIEW') && !notification.type.includes('RECRUITMENT');


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- EventStream으로 실시간 알림은 받아오지만, 알림 목록 조회가 안되는 문제를 해결했습니다.
<br><br>
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- `useNotification`에서 알림 목록을 조회할 때, `data.notification`으로 접근하던 것을 `data`로 수정했습니다.
 
알림 종
https://github.com/Ludo-SMP/ludo-frontend/blob/af37a4935931715302817fdf3d5e6b5f31425daa/src/Components/Header/AlarmBell/index.tsx#L31-L33

알림 설정
https://github.com/Ludo-SMP/ludo-frontend/blob/af37a4935931715302817fdf3d5e6b5f31425daa/src/Pages/Notifications/index.tsx#L40-L42
 
- 알림 목록이 없을 경우,  destructuring 할당 시 에러가 발생하기 때문에 빈 배열로 설정해서 에러를 해결했습니다.
 
https://github.com/Ludo-SMP/ludo-frontend/blob/ff41f18ebf417a1554c45ef6f5cf824e9d7eb90c/src/Hooks/useSSE.ts#L31-L36

- 매 커밋마다 동일한 test를 실행시키는 것은 비효율적이라 husky pre-commit에 yarn test 를 제거했습니다. 
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.