### PR TITLE
fix: 알림 쿼리 API response에 맞게 수정

### DIFF
--- a/src/Hooks/notifications/useNotifications.ts
+++ b/src/Hooks/notifications/useNotifications.ts
@@ -3,15 +3,11 @@ import { getNotifications } from '@/Apis/notification';
 import { NOTIFICATIONS } from '@/Constants/queryString';
 import { NotificationSSEType } from '@/Types/notifications';
 
-export interface NotificationResponse {
-  notification: NotificationSSEType[];
-}
-
 export const useNotifications = () => {
   return useQuery({
     queryKey: [...NOTIFICATIONS.NOTIFICATIONS],
     queryFn: () => getNotifications(),
-    select: (data: { data: { data: NotificationResponse } }) => data?.data?.data?.notification,
+    select: (data: { data: { data: NotificationSSEType[] } }) => data?.data?.data,
     staleTime: 60 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
   });

--- a/src/Hooks/notifications/useReadNotification.ts
+++ b/src/Hooks/notifications/useReadNotification.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { readNotifications } from '@/Apis/notification';
 import { NOTIFICATIONS } from '@/Constants/queryString';
-import { NotificationResponse } from './useNotifications';
+import { NotificationSSEType } from '@/Types/notifications';
 
 /** 알림 읽음 API */
 export const useReadNotification = (notificationIds: number[]) => {
@@ -12,14 +12,12 @@ export const useReadNotification = (notificationIds: number[]) => {
     mutationFn: () => readNotifications({ notificationIds: notificationIds }),
     onSuccess: () => {
       // 읽은 알림 쿼리 캐시에 반영
-      queryClient.setQueryData(NOTIFICATIONS.NOTIFICATIONS, (prev: { data: { data: NotificationResponse } }) => {
+      queryClient.setQueryData(NOTIFICATIONS.NOTIFICATIONS, (prev: { data: { data: NotificationSSEType[] } }) => {
         const newData = JSON.parse(JSON.stringify(prev));
 
         // 읽은 알림 read값 변경
         notificationIds?.map((notificationId) => {
-          const alarmArrIdx = prev?.data?.data?.notification.findIndex(
-            (alarm) => alarm.notificationId === notificationId,
-          );
+          const alarmArrIdx = prev?.data?.data?.findIndex((alarm) => alarm?.notificationId === notificationId);
           if (alarmArrIdx !== -1) {
             newData.data.data.notification[alarmArrIdx].read = true;
           }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 알림 쿼리 API response에 맞게 수정 (notification 제거)



### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
