### PR TITLE
알림 mock 필드 참조 에러 수정

### DIFF
--- a/src/Apis/notification.ts
+++ b/src/Apis/notification.ts
@@ -4,11 +4,14 @@ import {
   NotificationsSetting,
   NotificationsSettingConfigType,
   NotificationIds,
+  NotificationSSEType,
 } from '@/Types/notifications';
 import { httpClient } from '@/utils/axios';
 
 /** 알림 목록 API */
-export const getNotifications = () => httpClient.get(API_END_POINT.NOTIFICATIONS);
+export const getNotifications = (): Promise<{
+  data: Array<NotificationSSEType>;
+}> => httpClient.get(API_END_POINT.NOTIFICATIONS);
 
 /** 알림 읽음 API */
 export const readNotifications = (data: NotificationIds) => httpClient.post(API_END_POINT.READ_NOTIFICATIONS, data);

--- a/src/Apis/notification.ts
+++ b/src/Apis/notification.ts
@@ -10,7 +10,9 @@ import { httpClient } from '@/utils/axios';
 
 /** 알림 목록 API */
 export const getNotifications = (): Promise<{
-  data: Array<NotificationSSEType>;
+  data: {
+    data: Array<NotificationSSEType>;
+  };
 }> => httpClient.get(API_END_POINT.NOTIFICATIONS);
 
 /** 알림 읽음 API */

--- a/src/Components/Header/AlarmBell/index.tsx
+++ b/src/Components/Header/AlarmBell/index.tsx
@@ -10,7 +10,9 @@ import { Alarm } from '@/Assets';
 const AlarmBell = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const { data } = useNotifications();
+  const { data, isLoading } = useNotifications();
+
+  if (isLoading) return null;
 
   const { fetchSSE, eventSource } = useSSE();
 

--- a/src/Components/Header/AlarmBell/index.tsx
+++ b/src/Components/Header/AlarmBell/index.tsx
@@ -10,9 +10,7 @@ import { Alarm } from '@/Assets';
 const AlarmBell = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const { data, isLoading } = useNotifications();
-
-  if (isLoading) return null;
+  const { data } = useNotifications();
 
   const { fetchSSE, eventSource } = useSSE();
 

--- a/src/Hooks/notifications/useNotifications.ts
+++ b/src/Hooks/notifications/useNotifications.ts
@@ -6,7 +6,7 @@ export const useNotifications = () => {
   return useQuery({
     queryKey: [...NOTIFICATIONS.NOTIFICATIONS],
     queryFn: () => getNotifications(),
-    select: (data) => data?.data,
+    select: (data) => data?.data.data,
     staleTime: 60 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
   });

--- a/src/Hooks/notifications/useNotifications.ts
+++ b/src/Hooks/notifications/useNotifications.ts
@@ -1,13 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { getNotifications } from '@/Apis/notification';
 import { NOTIFICATIONS } from '@/Constants/queryString';
-import { NotificationSSEType } from '@/Types/notifications';
 
 export const useNotifications = () => {
   return useQuery({
     queryKey: [...NOTIFICATIONS.NOTIFICATIONS],
     queryFn: () => getNotifications(),
-    select: (data: { data: { data: NotificationSSEType[] } }) => data?.data?.data,
+    select: (data) => data?.data,
     staleTime: 60 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
   });

--- a/src/Mocks/data/mockNotifications.ts
+++ b/src/Mocks/data/mockNotifications.ts
@@ -1,124 +1,120 @@
 import { NOTIFICATIONS, NotificationSSEType, NotificationsSetting } from '@/Types/notifications';
 
-export const mockNotifications = {
-  data: {
-    notification: [
-      {
-        notificationId: 1,
-        title: NOTIFICATIONS.STUDY_APPLICANT,
-        content: NOTIFICATIONS.STUDY_APPLICANT,
-        type: 'STUDY_APPLICANT',
-        read: false,
-        params: {
-          studyId: 3,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 2,
-        title: NOTIFICATIONS.REVIEW_START,
-        content: NOTIFICATIONS.REVIEW_START,
-        type: 'REVIEW_START',
-        read: false,
-        params: {
-          studyId: 3,
-          userId: 5,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 3,
-        title: NOTIFICATIONS.RECRUITMENT,
-        content: NOTIFICATIONS.RECRUITMENT,
-        type: 'RECRUITMENT',
-        read: false,
-        params: {
-          recruitmentId: 6,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 4,
-        title: '스터디 LUDO 지원결과가 나왔습니다.',
-        content: '스터디 LUDO에 합류하게 되신 것을 축하드립니다.',
-        type: 'STUDY_APPLICANT_ACCEPT',
-        read: false,
-        params: {
-          studyId: 3,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 5,
-        title: '스터디 LUDO 지원결과가 나왔습니다.',
-        content: '스터디 LUDO와 함께할 수 없게 되었습니다. 다음에 좋은 인연으로 만날 수 있으면 좋겠습니다.',
-        type: 'STUDY_APPLICANT_REJECT',
-        read: false,
-        params: {
-          studyId: null as null,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 6,
-        title: '스터디 종료기간이 임박하였습니다.',
-        content: '스터디 종료기간이 임박하였습니다.',
-        type: 'STUDY_END_DATE',
-        read: false,
-        params: {
-          studyId: null as null,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 7,
-        title: '스터디 탈퇴 신청이 접수되었습니다.',
-        content: '스터디 LUDO에서 스터디원의 탈퇴 신청이 접수되었습니다.',
-        type: 'STUDY_PARTICIPANT_LEAVE_APPLY',
-        read: false,
-        params: {
-          studyId: 6,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 8,
-        title: '스터디 탈퇴자가 발생하였습니다.',
-        content: '스터디 탈퇴자가 발생하였습니다.',
-        type: 'STUDY_PARTICIPANT_LEAVE',
-        read: false,
-        params: {
-          studyId: 6,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 9,
-        title: '스터디원간 상호 리뷰가 완료되었습니다.',
-        content: '스터디원간 상호 리뷰가 완료되었습니다.',
-        type: 'REVIEW_PEER_FINISH',
-        read: false,
-        params: {
-          studyId: null as null,
-          userId: null as null,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-      {
-        notificationId: 10,
-        title: '진행 완료된 스터디에서 다른 스터디원의 리뷰가 업로드되었습니다.',
-        content: '진행 완료된 스터디에서 다른 스터디원의 리뷰가 업로드되었습니다.',
-        type: 'REVIEW_RECEIVE',
-        read: false,
-        params: {
-          studyId: 3,
-          userId: 3,
-        },
-        createdAt: '2024-05-21T20:34:19.884948',
-      },
-    ] satisfies Array<NotificationSSEType>,
+export const mockNotifications = [
+  {
+    notificationId: 1,
+    title: NOTIFICATIONS.STUDY_APPLICANT,
+    content: NOTIFICATIONS.STUDY_APPLICANT,
+    type: 'STUDY_APPLICANT',
+    read: false,
+    params: {
+      studyId: 3,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
   },
-};
+  {
+    notificationId: 2,
+    title: NOTIFICATIONS.REVIEW_START,
+    content: NOTIFICATIONS.REVIEW_START,
+    type: 'REVIEW_START',
+    read: false,
+    params: {
+      studyId: 3,
+      userId: 5,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+  {
+    notificationId: 3,
+    title: NOTIFICATIONS.RECRUITMENT,
+    content: NOTIFICATIONS.RECRUITMENT,
+    type: 'RECRUITMENT',
+    read: false,
+    params: {
+      recruitmentId: 6,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+  {
+    notificationId: 4,
+    title: '스터디 LUDO 지원결과가 나왔습니다.',
+    content: '스터디 LUDO에 합류하게 되신 것을 축하드립니다.',
+    type: 'STUDY_APPLICANT_ACCEPT',
+    read: false,
+    params: {
+      studyId: 3,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+  {
+    notificationId: 5,
+    title: '스터디 LUDO 지원결과가 나왔습니다.',
+    content: '스터디 LUDO와 함께할 수 없게 되었습니다. 다음에 좋은 인연으로 만날 수 있으면 좋겠습니다.',
+    type: 'STUDY_APPLICANT_REJECT',
+    read: false,
+    params: {
+      studyId: null as null,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+  {
+    notificationId: 6,
+    title: '스터디 종료기간이 임박하였습니다.',
+    content: '스터디 종료기간이 임박하였습니다.',
+    type: 'STUDY_END_DATE',
+    read: false,
+    params: {
+      studyId: null as null,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+  {
+    notificationId: 7,
+    title: '스터디 탈퇴 신청이 접수되었습니다.',
+    content: '스터디 LUDO에서 스터디원의 탈퇴 신청이 접수되었습니다.',
+    type: 'STUDY_PARTICIPANT_LEAVE_APPLY',
+    read: false,
+    params: {
+      studyId: 6,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+  {
+    notificationId: 8,
+    title: '스터디 탈퇴자가 발생하였습니다.',
+    content: '스터디 탈퇴자가 발생하였습니다.',
+    type: 'STUDY_PARTICIPANT_LEAVE',
+    read: false,
+    params: {
+      studyId: 6,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+  {
+    notificationId: 9,
+    title: '스터디원간 상호 리뷰가 완료되었습니다.',
+    content: '스터디원간 상호 리뷰가 완료되었습니다.',
+    type: 'REVIEW_PEER_FINISH',
+    read: false,
+    params: {
+      studyId: null as null,
+      userId: null as null,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+  {
+    notificationId: 10,
+    title: '진행 완료된 스터디에서 다른 스터디원의 리뷰가 업로드되었습니다.',
+    content: '진행 완료된 스터디에서 다른 스터디원의 리뷰가 업로드되었습니다.',
+    type: 'REVIEW_RECEIVE',
+    read: false,
+    params: {
+      studyId: 3,
+      userId: 3,
+    },
+    createdAt: '2024-05-21T20:34:19.884948',
+  },
+] satisfies Array<NotificationSSEType>;
 
 export const mockNotificationsSetting: NotificationsSetting = {
   allConfig: {

--- a/src/Mocks/handlers/SSEnotification.ts
+++ b/src/Mocks/handlers/SSEnotification.ts
@@ -35,7 +35,7 @@ const subscribeSSE = http.get(`${baseURL}/api/notifications/subscribe`, async ()
 const getNotifications = http.get(`${baseURL}/api/notifications`, async () => {
   return new HttpResponse(
     JSON.stringify({
-      data: mockNotifications.data,
+      data: mockNotifications,
       message: 'Success',
     }),
     {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 알림 목록을 불러올 때 mock에서 잘못된 필드를 참조하는 에러 해결
<br><br>

### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
