### PR TITLE
스택 모달에서 chip 영역이 overflow 되었을 시, scroll이 되도록 수정

### DIFF
--- a/src/Components/Modal/StackModal/index.tsx
+++ b/src/Components/Modal/StackModal/index.tsx
@@ -224,7 +224,7 @@ const CategoryChipsWrapper = styled.div`
   width: 100%;
   align-items: flex-start;
   gap: 8px;
-  overflow-x: hidden;
+  overflow-x: scroll;
 `;
 
 const TechStackListWrapper = styled.div`


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
스택 모달에서 chip 영역이 overflow 되었을 시, scroll이 되도록 수정

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
