### PR TITLE
출석 버튼 클릭 시 낙관적 업데이트 적용

### DIFF
--- a/src/Components/Common/Modal/index.tsx
+++ b/src/Components/Common/Modal/index.tsx
@@ -45,11 +45,11 @@ const Modal = ({
   return (
     <ModalBackDropWrapper>
       <ModalWrapper>
-        <ModalInfoWrapper alignTitle={alignTitle}>
+        <ModalInfoWrapper $alignTitle={alignTitle}>
           <div className="title">{title}</div>
           <ModalContentWrapper>{children}</ModalContentWrapper>
         </ModalInfoWrapper>
-        <ModalBtnsWrapper onClick={closeModal} isBtnWidthEqual={isBtnWidthEqual} cancelBtnText={cancelBtnText}>
+        <ModalBtnsWrapper onClick={closeModal} $isBtnWidthEqual={isBtnWidthEqual} cancelBtnText={cancelBtnText}>
           {cancelBtnText && (
             <Button className="cancel__btn" onClick={handleCancel ? handleCancel : closeModal}>
               {cancelBtnText}
@@ -89,7 +89,7 @@ const ModalWrapper = styled.div`
   border: 1px solid ${({ theme }) => theme.color.black1};
 `;
 
-const ModalInfoWrapper = styled.div<{ alignTitle: 'flex-start' | 'center' }>`
+const ModalInfoWrapper = styled.div<{ $alignTitle: 'flex-start' | 'center' }>`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -100,7 +100,7 @@ const ModalInfoWrapper = styled.div<{ alignTitle: 'flex-start' | 'center' }>`
     justify-content: center;
     height: 40px;
     padding: 5px 0px;
-    justify-content: ${(props) => props.alignTitle};
+    justify-content: ${(props) => props.$alignTitle};
     align-items: center;
     align-self: stretch;
     color: ${({ theme }) => theme.color.black5};
@@ -135,10 +135,10 @@ const ModalContentWrapper = styled.div`
   }
 `;
 
-const ModalBtnsWrapper = styled.div<{ isBtnWidthEqual: boolean; cancelBtnText: string }>`
+const ModalBtnsWrapper = styled.div<{ $isBtnWidthEqual: boolean; cancelBtnText: string }>`
   display: grid;
   grid-template-columns: ${(props) =>
-    props.cancelBtnText ? (props.isBtnWidthEqual ? `1fr 1fr` : `158fr 338fr`) : '1fr'};
+    props.cancelBtnText ? (props.$isBtnWidthEqual ? `1fr 1fr` : `158fr 338fr`) : '1fr'};
   align-items: flex-start;
   grid-gap: 24px;
   align-self: stretch;

--- a/src/Hooks/study/useAttendStudyMutation.ts
+++ b/src/Hooks/study/useAttendStudyMutation.ts
@@ -1,9 +1,26 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { STUDY } from '@/Constants/queryString';
 import { attendStudy } from '@/Apis/study';
+import { StudyDetail } from '@/Types/study';
+import { Participant } from '@/Types/study';
 
-export const useAttendStudyMutation = (studyId: number) =>
-  useMutation({
+export const useAttendStudyMutation = (studyId: number, userId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
     mutationKey: [...STUDY.STUDY(studyId)],
     mutationFn: () => attendStudy(studyId),
+    onSuccess: () => {
+      queryClient.setQueryData([...STUDY.STUDY(studyId)], (prev: { data: { data: StudyDetail } }) => {
+        const newvStudyDetailData: { data: { data: StudyDetail } } = JSON.parse(JSON.stringify(prev));
+        newvStudyDetailData.data.data.study.participants = newvStudyDetailData?.data?.data?.study?.participants
+          ? newvStudyDetailData?.data?.data?.study?.participants.map((participant: Participant) => {
+              return participant.id === userId
+                ? { ...participant, recentAttendanceDate: new Date().toISOString() }
+                : { ...participant };
+            })
+          : [];
+        return newvStudyDetailData;
+      });
+    },
   });
+};

--- a/src/Hooks/study/useAttendStudyMutation.ts
+++ b/src/Hooks/study/useAttendStudyMutation.ts
@@ -15,10 +15,15 @@ export const useAttendStudyMutation = (studyId: number, userId: number) => {
         newvStudyDetailData.data.data.study.participants = newvStudyDetailData?.data?.data?.study?.participants
           ? newvStudyDetailData?.data?.data?.study?.participants.map((participant: Participant) => {
               return participant.id === userId
-                ? { ...participant, recentAttendanceDate: new Date().toISOString() }
+                ? {
+                    ...participant,
+                    recentAttendanceDate: new Date().toISOString(),
+                    totalAttendance: participant.totalAttendance + 1,
+                  }
                 : { ...participant };
             })
           : [];
+
         return newvStudyDetailData;
       });
     },

--- a/src/Pages/StudyDetail/index.tsx
+++ b/src/Pages/StudyDetail/index.tsx
@@ -211,7 +211,7 @@ const StudyTitle = styled.div`
 
 const StudyTitleText = styled.span`
   color: ${({ theme }) => theme.color.black5};
-  font-family: Pretendard600;
+  font-family: 'Pretendard600';
   font-size: 18px;
   font-style: normal;
   font-weight: 600;
@@ -275,7 +275,7 @@ const WeekdaySection = styled.div`
 
 const TopBarSectionTitle = styled.span`
   color: ${({ theme }) => theme.color.black5};
-  font-family: Pretendard500;
+  font-family: 'Pretendard500';
   font-size: 18px;
   font-style: normal;
   font-weight: 500;
@@ -284,7 +284,7 @@ const TopBarSectionTitle = styled.span`
 
 const TopBarSectionText = styled.span`
   color: ${({ theme }) => theme.color.black2};
-  font-family: Pretendard500;
+  font-family: 'Pretendard500';
   font-size: 18px;
   font-style: normal;
   font-weight: 500;
@@ -311,7 +311,7 @@ const MemberCounts = ({ count }: { count: number }) => (
   <MemberCountsBox>
     <MemberImage />
     <MemberCountsText>
-      구성원 <MemberCountsTextCaption>({count})</MemberCountsTextCaption>
+      구성원 <MemberCountsTextCaption>({count}명)</MemberCountsTextCaption>
     </MemberCountsText>
   </MemberCountsBox>
 );
@@ -324,7 +324,7 @@ const MemberCountsBox = styled.div`
 
 const MemberCountsText = styled.span`
   color: ${({ theme }) => theme.color.black5};
-  font-family: Pretendard600;
+  font-family: 'Pretendard600';
   font-size: 18px;
   font-style: normal;
   font-weight: 600;
@@ -332,8 +332,8 @@ const MemberCountsText = styled.span`
 `;
 
 const MemberCountsTextCaption = styled.span`
-  color: #00000080;
-  font-family: Pretendard600;
+  color: rgba(0, 0, 0, 0.5);
+  font-family: 'Pretendard600';
   font-size: 18px;
   font-style: normal;
   font-weight: 600;

--- a/src/Pages/StudyDetail/index.tsx
+++ b/src/Pages/StudyDetail/index.tsx
@@ -41,7 +41,7 @@ export const StudyDetailPage = () => {
     mutate: attendStudyMutate,
     isSuccess: isAttendStudyMutationSuccess,
     isError: isAttendStudyMutationError,
-  } = useAttendStudyMutation(studyId);
+  } = useAttendStudyMutation(studyId, user?.id);
 
   const [isAttendanceModalOpen, setIsAttendanceModalOpen] = useState(true);
   const [isErrorModalOpen, setIsErrorModalOpen] = useState(true);

--- a/src/Pages/StudyDetail/index.tsx
+++ b/src/Pages/StudyDetail/index.tsx
@@ -303,7 +303,7 @@ const Members = styled.div`
 const MembersCountBar = styled.div`
   display: flex;
   align-items: center;
-  gap: 632px;
+  justify-content: space-between;
   align-self: stretch;
 `;
 
@@ -318,7 +318,7 @@ const MemberCounts = ({ count }: { count: number }) => (
 
 const MemberCountsBox = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
 `;
 


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.
- [x] 출석 버튼 클릭 시 낙관적 업데이트 적용

## 💡 이슈를 처리하면서 추가된 코드가 있어요.

### 🛠 출석 버튼 클릭 시 낙관적 업데이트 적용
사용자가 출석 버튼 클릭 시, 출석 처리를 하기위해 사용자의 최근출석 시간 Data를 낙관적 업데이트 처리하였습니다.

https://github.com/Ludo-SMP/ludo-frontend/blob/c852063b8c5410c4b05e20e853c35d087c4f290b/src/Hooks/study/useAttendStudyMutation.ts#L7-L31


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
