### PR TITLE
fix: 스터디 모집 공고 버튼 숨김

### DIFF
--- a/src/Pages/RecruitmentDetail/ApplySection.tsx
+++ b/src/Pages/RecruitmentDetail/ApplySection.tsx
@@ -70,15 +70,6 @@ const ApplySection = ({ isMine, recruitment, study }: ApplySectionProps) => {
               스터디 지원하기
             </Button>
           )}
-          <Button
-            scheme="normal"
-            onClick={() => {
-              setCloseRecruitment(true);
-              openModal();
-            }}
-          >
-            모집 마감하기
-          </Button>
         </ButtonBox>
       )}
 


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 자신이 소유한 스터디가 아닌 스터디의 모집 공고 화면에서도 스터디 마감하기 버튼을 클릭할 수 있었지만 자신의 스터디 모집공고가 아니면 마감 버튼을 클릭할 수 없도록 수정했습니다.

전:
![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/45ec5644-89f5-4a61-a79f-3fec39afeb5b)

후:
![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/d64a54e4-d876-40d3-8a14-a1df40214cc9)

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
