### PR TITLE
fix: `<CircularRate />` 소수점 생략

### DIFF
--- a/src/Components/CircularRate/CircularRate.spec.tsx
+++ b/src/Components/CircularRate/CircularRate.spec.tsx
@@ -3,7 +3,7 @@ import Render from '@/__test__/Render';
 import '@testing-library/jest-dom';
 
 describe('CircularRate', () => {
-  it('Button 컴포넌트 텍스트 확인', () => {
+  it('자릿수는 항상 내림되어야 한다', () => {
     const { container } = Render(<CircularRate percentage={(4 / 7) * 100} label="전문성" />);
 
     expect(container).toHaveTextContent('57');

--- a/src/Components/CircularRate/CircularRate.spec.tsx
+++ b/src/Components/CircularRate/CircularRate.spec.tsx
@@ -1,0 +1,11 @@
+import { CircularRate } from '.';
+import Render from '@/__test__/Render';
+import '@testing-library/jest-dom';
+
+describe('CircularRate', () => {
+  it('Button 컴포넌트 텍스트 확인', () => {
+    const { container } = Render(<CircularRate percentage={(4 / 7) * 100} label="전문성" />);
+
+    expect(container).toHaveTextContent('57');
+  });
+});

--- a/src/Components/CircularRate/index.tsx
+++ b/src/Components/CircularRate/index.tsx
@@ -59,7 +59,7 @@ export const CircularRate = ({
         </foreignObject>
       </svg>
       <InnerBox $size={size}>
-        <ProgressText>{percentage}%</ProgressText>
+        <ProgressText>{Math.floor(percentage)}%</ProgressText>
         <LabelText>{label}</LabelText>
       </InnerBox>
     </Box>


### PR DESCRIPTION
#322 

### 💡 다음 이슈를 해결했어요.
- `<CircularRate />` 컴포넌트의 비율이 소수로 나오는 경우, 내림하여 숫자를 정수로 맞춥니다.

|||
| :---: | :---: |
| ![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/06f45ae0-185b-4b87-b902-3b937cd591d1) | ![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/f7c52a69-417f-44b0-9f93-41f02a51dc0e) |
| 전 | 후 |

<br><br>
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- 유닛 테스트 추가
  https://github.com/Ludo-SMP/ludo-frontend/blob/312435293d46605fde6127370e62561ce1d40e36/src/Components/CircularRate/CircularRate.spec.tsx#L6-L10
<br><br>

### 💡 필요한 후속작업이 있어요.
- #322의 다른 이슈 해결
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
