### PR TITLE
feat: 스터디 지원 승인시 지원자 목록 재조회

### DIFF
--- a/src/Hooks/study/useAcceptApplyMutation.ts
+++ b/src/Hooks/study/useAcceptApplyMutation.ts
@@ -1,15 +1,17 @@
 import { useModalStore } from '@/store/modal';
 import { STUDY } from '@/Constants/queryString';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { acceptApply } from '@/Apis/study';
 
 export const useAcceptApplyMutation = (studyId: number, applicantId: number, successHandler: () => void) => {
   const { openModal } = useModalStore();
+  const queryClient = useQueryClient();
 
   const { mutate } = useMutation({
     mutationKey: [...STUDY.APPLY_ACCEPT(studyId, applicantId)],
     mutationFn: () => acceptApply(studyId, applicantId),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [STUDY.APPLICNATS(studyId)] });
       successHandler();
       openModal();
     },


### PR DESCRIPTION
<!--- 
# 뒤에 머지 후 close할 이슈번호를 작성
# 자동으로 close 됩니다.
<strong>
Closes #
</strong>
--->
### 💡 다음 이슈를 해결했어요.
- 스터디 지원자의 지원을 승인했을 때, 즉시 쿼리를 invalidate해 지원자 목록을 다시 불러오도록 수정했습니다.
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
