### PR TITLE
feat: 사용자 프로필 사진 Gravatar 표시

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@storybook/test": "^8.0.8",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^15.0.2",
+    "@types/crypto-js": "^4.2.2",
     "@types/event-source-polyfill": "^1.0.5",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.10",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/react-slick": "^0.23.13",
     "@types/styled-components": "^5.1.34",
     "axios": "^1.6.7",
+    "crypto-js": "^4.2.0",
     "date-fns": "^3.6.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",

--- a/src/Assets/Profile.stories.ts
+++ b/src/Assets/Profile.stories.ts
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Profile } from './Profile';
+
+const meta = {
+  component: Profile,
+} satisfies Meta<typeof Profile>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {} satisfies Story;
+
+/** 이메일 주소가 있을 경우, 해당 이메일 주소의 Gravatar 이미지를 불러옵니다. */
+export const Gravatar: Story = {
+  args: {
+    email: 'support@ludo.study',
+  },
+} satisfies Story;

--- a/src/Assets/Profile.tsx
+++ b/src/Assets/Profile.tsx
@@ -25,17 +25,7 @@ const toGravatar = (email: string) =>
  */
 export const Profile = ({ width = 60, height = 60, email }: ProfileProps) => {
   // NOTE: 채움 프로필 이미지 관련 코드는 임시 구현이며, 추후 이미지 업로드 기능이 구현되면 제거될 예정입니다.
-  if (email)
-    return (
-      <ClippedImage
-        src={toGravatar(email)}
-        width={width}
-        height={height}
-        style={{
-          borderRadius: '50%',
-        }}
-      />
-    );
+  if (email) return <ClippedImage src={toGravatar(email)} width={width} height={height} />;
 
   const maskId = useId();
 

--- a/src/Assets/Profile.tsx
+++ b/src/Assets/Profile.tsx
@@ -4,7 +4,7 @@ import CryptoJS from 'crypto-js';
 export interface ProfileProps {
   width?: number;
   height?: number;
-  email: string;
+  email?: string;
 }
 
 const toGravatar = (email: string) =>

--- a/src/Assets/Profile.tsx
+++ b/src/Assets/Profile.tsx
@@ -1,5 +1,6 @@
 import { useId } from 'react';
 import CryptoJS from 'crypto-js';
+import styled from 'styled-components';
 
 export interface ProfileProps {
   width?: number;
@@ -10,10 +11,14 @@ export interface ProfileProps {
 const toGravatar = (email: string) =>
   `https://gravatar.com/avatar/${CryptoJS.MD5(email.trim().toLowerCase()).toString()}?d=identicon`;
 
+/**
+ * 프로필 이미지 컴포넌트
+ */
 export const Profile = ({ width = 60, height = 60, email }: ProfileProps) => {
+  // NOTE: 채움 프로필 이미지 관련 코드는 임시 구현이며, 추후 이미지 업로드 기능이 구현되면 제거될 예정입니다.
   if (email)
     return (
-      <img
+      <ClippedImage
         src={toGravatar(email)}
         width={width}
         height={height}
@@ -84,3 +89,7 @@ export const Profile = ({ width = 60, height = 60, email }: ProfileProps) => {
     </svg>
   );
 };
+
+const ClippedImage = styled.img`
+  borderradius: 50%;
+`;

--- a/src/Assets/Profile.tsx
+++ b/src/Assets/Profile.tsx
@@ -1,12 +1,30 @@
 import { useId } from 'react';
+import CryptoJS from 'crypto-js';
 
 export interface ProfileProps {
   width?: number;
   height?: number;
+  email: string;
 }
 
-export const Profile = ({ width = 60, height = 60 }: ProfileProps) => {
+const toGravatar = (email: string) =>
+  `https://gravatar.com/avatar/${CryptoJS.MD5(email.trim().toLowerCase()).toString()}?d=identicon`;
+
+export const Profile = ({ width = 60, height = 60, email }: ProfileProps) => {
+  if (email)
+    return (
+      <img
+        src={toGravatar(email)}
+        width={width}
+        height={height}
+        style={{
+          borderRadius: '50%',
+        }}
+      />
+    );
+
   const maskId = useId();
+
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox="0 0 60 60" fill="none">
       <mask id={`profile-${maskId}`} type="luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="60" height="60">

--- a/src/Assets/Profile.tsx
+++ b/src/Assets/Profile.tsx
@@ -3,8 +3,17 @@ import CryptoJS from 'crypto-js';
 import styled from 'styled-components';
 
 export interface ProfileProps {
+  /** 프로필 이미지 너비 */
   width?: number;
+
+  /** 프로필 이미지 높이 */
   height?: number;
+
+  /**
+   * Gravatar 이미지를 위한 이메일 주소
+   *
+   * 해당 이메일 주소에 해당하는 고유한 Gravatar 이미지가 생성 또는 불러와집니다.
+   */
   email?: string;
 }
 

--- a/src/Components/ApplicantCard/index.tsx
+++ b/src/Components/ApplicantCard/index.tsx
@@ -47,7 +47,7 @@ export const ApplicantCard = ({
         <Title>{title}</Title>
         <Content>
           <ProfileSection>
-            <Profile width={100} height={100} />
+            <Profile width={100} height={100} email={email} />
             <ProfileInfoBox>
               <Nickname>{nickname}</Nickname>
               <Fields>

--- a/src/Components/Header/index.tsx
+++ b/src/Components/Header/index.tsx
@@ -14,10 +14,14 @@ import { useModalStore } from '@/store/modal';
 import { useLogOutMutation } from '@/Hooks/auth/useLogOutMutation';
 import DropdownItem from '../Common/DropdownItem';
 import { AlarmBell } from './AlarmBell';
+import { useUserStore } from '@/store/user';
 
 /** 사이트 메인 헤더 */
 const Header = () => {
   const { isLoggedIn } = useLoginStore();
+  const {
+    user: { email },
+  } = useUserStore();
   const { openModal } = useModalStore();
   const navigate = useNavigate();
   const currentLocation = useLocation()?.pathname;
@@ -51,7 +55,7 @@ const Header = () => {
               )}
               <UserInfoWrapper>
                 <AlarmBell />
-                <Dropdown image={<Profile width={40} height={40} />}>
+                <Dropdown image={<Profile width={40} height={40} email={email} />}>
                   <DropdownItem
                     onClick={() => {
                       navigate(ROUTES.MYPAGE.HOME);

--- a/src/Components/MemberProfile/index.tsx
+++ b/src/Components/MemberProfile/index.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { ColumnDivider } from '../Common/Divider/ColumnDivider';
-import { More } from '@/Assets';
 import { Profile } from '@/Assets/Profile';
 import { Member } from '@/Types/study';
 import { ROLE } from '@/Shared/study';
@@ -16,6 +15,7 @@ import { LEAVE } from '@/Constants/messages';
 import Button from '../Common/Button';
 import { useApproveStudyLeaveRequest } from '@/Hooks/study/useApproveStudyLeaveRequest';
 import { useRejectStudyLeaveMutation } from '@/Hooks/study/useRejectStudyLeaveRequest';
+import { More } from '@/Assets';
 
 export interface MemberProfileProps extends Member {
   /** 스터디원의 프로필 이미지 URL */
@@ -83,7 +83,7 @@ const MemberProfile = ({
           )}
         </OptionsButton>
       )}
-      <Profile width={120} height={120} />
+      <Profile width={120} height={120} email={email} />
       {match(state)
         .with(P.union('needLeaveApproval', 'needReview'), () => (
           <>

--- a/src/Components/ProfileSection/ProfileSection.tsx
+++ b/src/Components/ProfileSection/ProfileSection.tsx
@@ -15,7 +15,7 @@ export const ProfileSection = ({ nickname, email }: ProfileSectionProps) => {
   return (
     <Box>
       <ProfileBox>
-        <Profile width={160} height={160} />
+        <Profile width={160} height={160} email={email} />
         <SettingButton nickname="nickname" />
       </ProfileBox>
       <NameBox>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4527,6 +4527,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
+
 crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,6 +2964,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/crypto-js@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.2.tgz#771c4a768d94eb5922cc202a3009558204df0cea"
+  integrity sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==
+
 "@types/debug@^4.0.0":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"


### PR DESCRIPTION
![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/97eae42f-1048-4851-98e6-04c651119152)

<!--- 
# 뒤에 머지 후 close할 이슈번호를 작성
# 자동으로 close 됩니다.
<strong>
Closes #
</strong>
--->
### 💡 다음 이슈를 해결했어요.
- 스터디 멤버, 스터디 지원자, 상단 프로필, 마이페이지에서 gravatar를 표시합니다.
<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- 사용자의 이메일 정보를 통해 gravatar를 추출해냅니다.
  https://github.com/Ludo-SMP/ludo-frontend/blob/d1430ff5edfab43ac17f23596ef28c236988cea7/src/Assets/Profile.tsx#L10-L11
<br><br>
- Gravatar를 기본 SVG 대신 표시합니다.
  https://github.com/Ludo-SMP/ludo-frontend/blob/562d8f20a89f35a95ab163e4fc0c1247c66a8c5a/src/Assets/Profile.tsx#L27-L28

### 💡 필요한 후속작업이 있어요.
- 팀원들과 적용 논의
- 스터디원 리뷰 페이지 반영
<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- https://docs.gravatar.com/api/avatars/images/
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
