### PR TITLE
fix: 평균 출석률 자릿수 고정

### DIFF
--- a/src/Pages/MyPage/UserInfoSection.tsx
+++ b/src/Pages/MyPage/UserInfoSection.tsx
@@ -41,7 +41,7 @@ const UserInfoSection = ({ myPageInfo }: UserInfoSectionProps) => {
               </InfoText>
               <InfoText>
                 <span className="info__label">평균 출석률</span>
-                <span className="info__description">{trust?.averageAttendanceRate || 0} 퍼센트</span>
+                <span className="info__description">{trust?.averageAttendanceRate.toFixed(2) || 0}%</span>
               </InfoText>
             </InfoItem>
           </UserInfoRow>


### PR DESCRIPTION
<strong>
Closes #322
</strong>

### 💡 다음 이슈를 해결했어요.
- 평균 출석률 계산시 소수점 2자리까지만 표시되도록 수정했습니다.
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
