### PR TITLE
fix: 스터디 종료, 또는 스터디장의 경우 탈퇴 불가

### DIFF
--- a/src/Components/MemberProfile/index.tsx
+++ b/src/Components/MemberProfile/index.tsx
@@ -72,6 +72,7 @@ const MemberProfile = ({
           <More />
           {isOptionsOpen && (
             <Options
+              enableLeaveButton={role !== 'OWNER' && state !== 'needReview' && state !== 'reviewEnd'}
               onSelect={(action) => (
                 match(action)
                   .with('leave', () => setIsLeaveModalOpen(true))
@@ -167,9 +168,11 @@ const MemberProfile = ({
 };
 
 const Options = ({
+  enableLeaveButton = false,
   onClose = () => void 0,
   onSelect = () => void 0,
 }: {
+  enableLeaveButton?: boolean;
   onClose?: () => void;
   onSelect: (action: 'leave') => void;
 }) => {
@@ -187,7 +190,7 @@ const Options = ({
       <MenuItem>
         <Link to={ROUTES.MYPAGE.HOME}>마이 페이지</Link>
       </MenuItem>
-      <MenuItem onClick={() => onSelect('leave')}>스터디 탈퇴하기</MenuItem>
+      {enableLeaveButton && <MenuItem onClick={() => onSelect('leave')}>스터디 탈퇴하기</MenuItem>}
     </Menu>
   );
 };


### PR DESCRIPTION
<!--- 
# 뒤에 머지 후 close할 이슈번호를 작성
# 자동으로 close 됩니다.
<strong>
Closes #
</strong>
--->
### 💡 다음 이슈를 해결했어요.
- 스터디가 이미 종료되었거나, 스터디장일 경우는 탈퇴 메뉴가 표시될 수 없도록 바꾸었어요.
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
