### PR TITLE
feat: 리뷰 페이지 리뷰이 데이터 바인딩

### DIFF
--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -59,7 +59,9 @@ export const ReviewPage = () => {
     study: { title, participants },
   } = study;
   const {
+    id,
     nickname,
+    email,
     position: { name },
   } = participants.find((participant) => participant.id === parseInt(userId));
 
@@ -76,7 +78,7 @@ export const ReviewPage = () => {
                 <MemberTitleText>함께한 스터디원</MemberTitleText>
               </MemberTitle>
               <MemberProfile>
-                <Profile width={80} height={80} />
+                <Profile width={80} height={80} email={email} />
                 <MemberProfileBox>
                   <MemberName>{nickname}</MemberName>
                   <MemberStudyInfo>

--- a/src/Pages/Review/index.tsx
+++ b/src/Pages/Review/index.tsx
@@ -2,13 +2,14 @@ import { Profile } from '@/Assets/Profile';
 import Button from '@/Components/Common/Button';
 import { RowDivider } from '@/Components/Common/Divider/RowDivider';
 import styled from 'styled-components';
-import { MemberImage } from '@/Assets';
+import { Loading, MemberImage } from '@/Assets';
 import { ColumnDivider } from '@/Components/Common/Divider/ColumnDivider';
 import { ReviewQuestion } from '@/Components/ReviewQuestion/ReviewQuestion';
 import { Controller, useForm } from 'react-hook-form';
 import { HeaderWithLogo } from '@/Components/Header/HeaderWithLogo';
 import { useSubmitReviewMutation } from '@/Hooks/review/useSubmitReviewMutation';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useStudyDetail } from '@/Hooks/study/useStudyDetail';
 
 const reviewDataList = {
   activenessScore: {
@@ -43,12 +44,24 @@ type ReviewResult = Record<keyof typeof reviewDataList, number>;
 export const ReviewPage = () => {
   const { studyId, userId } = useParams();
   const navigate = useNavigate();
+
+  const { data: study, isLoading } = useStudyDetail(parseInt(studyId));
   const { mutate } = useSubmitReviewMutation(parseInt(studyId), () => navigate(`/studies/${studyId}`));
   const {
     handleSubmit,
     formState: { errors },
     control,
   } = useForm<ReviewResult>();
+
+  if (isLoading) return <Loading />;
+
+  const {
+    study: { title, participants },
+  } = study;
+  const {
+    nickname,
+    position: { name },
+  } = participants.find((participant) => participant.id === parseInt(userId));
 
   return (
     <ReviewPageLayout>
@@ -65,11 +78,11 @@ export const ReviewPage = () => {
               <MemberProfile>
                 <Profile width={80} height={80} />
                 <MemberProfileBox>
-                  <MemberName>닉네임</MemberName>
+                  <MemberName>{nickname}</MemberName>
                   <MemberStudyInfo>
-                    <MemberStudyInfoText>스터디 이름</MemberStudyInfoText>
+                    <MemberStudyInfoText>{title}</MemberStudyInfoText>
                     <ColumnDivider />
-                    <MemberStudyInfoText>포지션</MemberStudyInfoText>
+                    <MemberStudyInfoText>{name}</MemberStudyInfoText>
                   </MemberStudyInfo>
                 </MemberProfileBox>
               </MemberProfile>


### PR DESCRIPTION
![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/bf939965-0c46-44e0-810f-170b3d788335)

### 💡 다음 이슈를 해결했어요.
- 기존 화면에서는 리뷰 페이지에 하드코딩된 기본 값이 보였지만, 스터디 상세 쿼리의 정보를 사용해 리뷰이의 이름, 프로필 사진, 포지션 등을 표시합니다.
<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- (없다면 이 문항을 지워주세요.)
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
