### PR TITLE
feat: 출석일을 제외한 날에는 출석 버튼 비활성화

### DIFF
--- a/src/Pages/StudyDetail/index.tsx
+++ b/src/Pages/StudyDetail/index.tsx
@@ -16,7 +16,7 @@ import { match, P } from 'ts-pattern';
 import { Sidebar } from './Sidebar';
 import { useAttendStudyMutation } from '@/Hooks/study/useAttendStudyMutation';
 import { isToday } from 'date-fns';
-import { getDayById } from '@/utils/date';
+import { getDayById, isTodayAttendanceDay } from '@/utils/date';
 
 const isValidUrl = (url: string) => {
   try {
@@ -76,13 +76,18 @@ export const StudyDetailPage = () => {
               <PlatformSection>
                 <PlatformTitle>
                   <TopBarSectionTitle>진행 플랫폼</TopBarSectionTitle>
-                  {didIAttendToday ? (
-                    <Button disabled>출석 완료</Button>
-                  ) : (
-                    <Button scheme="secondary" onClick={async () => attendStudyMutate()}>
-                      출석 체크
-                    </Button>
-                  )}
+                  {study.status !== 'COMPLETED' &&
+                    (isTodayAttendanceDay(study.attendanceDay) ? (
+                      didIAttendToday ? (
+                        <Button disabled>출석 완료</Button>
+                      ) : (
+                        <Button scheme="secondary" onClick={async () => attendStudyMutate()}>
+                          출석 체크
+                        </Button>
+                      )
+                    ) : (
+                      <Button disabled>출석 없음</Button>
+                    ))}
                   {isAttendanceModalOpen && isAttendStudyMutationSuccess && (
                     <Modal
                       title="해당 스터디 출석이 체크되었습니다!"

--- a/src/Pages/StudyDetail/index.tsx
+++ b/src/Pages/StudyDetail/index.tsx
@@ -16,16 +16,7 @@ import { match, P } from 'ts-pattern';
 import { Sidebar } from './Sidebar';
 import { useAttendStudyMutation } from '@/Hooks/study/useAttendStudyMutation';
 import { isToday } from 'date-fns';
-
-const dayMap = {
-  1: '월요일',
-  2: '화요일',
-  3: '수요일',
-  4: '목요일',
-  5: '금요일',
-  6: '토요일',
-  7: '일요일',
-};
+import { getDayById } from '@/utils/date';
 
 const isValidUrl = (url: string) => {
   try {
@@ -65,7 +56,7 @@ export const StudyDetailPage = () => {
     new Date(study?.participants?.find(({ id }) => id === user?.id)?.recentAttendanceDate),
   );
 
-  const attendDays = study?.attendanceDay?.map((day) => dayMap[day]).join(', ') ?? '출석 요일';
+  const attendDays = getDayById(study?.attendanceDay);
 
   return (
     <Grid>

--- a/src/Shared/study.ts
+++ b/src/Shared/study.ts
@@ -1,3 +1,4 @@
+import { AttendanceDay } from '@/Types/atoms';
 import { generateSharedObjectByCustomKey } from '@/utils/selectUtil';
 
 export interface OriginalShared {
@@ -104,7 +105,7 @@ export const ROLE = {
   PENDING: '탈퇴 요청',
 };
 
-export const NEW_ATTENDANCE_DAY: OriginalShared = {
+export const NEW_ATTENDANCE_DAY = {
   1: '월요일',
   2: '화요일',
   3: '수요일',
@@ -112,6 +113,6 @@ export const NEW_ATTENDANCE_DAY: OriginalShared = {
   5: '금요일',
   6: '토요일',
   7: '일요일',
-};
+} satisfies Record<AttendanceDay, string>;
 
 export const ATTENDANCE_DAY = generateDropdownOption(NEW_ATTENDANCE_DAY);

--- a/src/Types/atoms.ts
+++ b/src/Types/atoms.ts
@@ -12,3 +12,12 @@
 
 /** 특정한 시간 범위를 나타내는 타입입니다. */
 export type DateRange = [Date, Date];
+
+/**
+ * 출석요일
+ *
+ * 1: 월요일 ~ 7: 일요일
+ *
+ * 0이 일요일이 아님에 주의.
+ */
+export type AttendanceDay = 1 | 2 | 3 | 4 | 5 | 6 | 7;

--- a/src/Types/study.ts
+++ b/src/Types/study.ts
@@ -1,4 +1,5 @@
 import { APPLY_STATUS, POSITION, MEMBER_STATUS, PLATFORM, PROGRESS_METHOD, ROLE, STUDY_STATUS } from '@/Shared/study';
+import { AttendanceDay } from './atoms';
 
 export type CategoryPropertyType = 'category' | 'stacks' | 'positions' | 'way' | 'sort';
 export type StudyStatus = keyof typeof STUDY_STATUS;
@@ -170,13 +171,6 @@ export interface Applicant extends User {
     recommend: number;
   };
 }
-
-/**
- * 출석요일
- *
- * 1: 월요일 ~ 7: 일요일
- */
-export type AttendanceDay = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
 export interface StudyCreate {
   title: string;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -78,15 +78,13 @@ export const getMillisec = (uuidStr: string) => {
 /**
  * @description 출석일에 해당하는 숫자를 요일로 변환한다.
  */
-export const getDayById = (ids: number[]) => {
-  return ids?.map((id: number) => NEW_ATTENDANCE_DAY[id].toString().slice(0, 1)).join(', ');
-};
+export const getDayById = (ids: AttendanceDay[]) => ids.map((id) => NEW_ATTENDANCE_DAY[id].slice(0, 1)).join(', ');
 
 /**
  * @description 출석일 id 배열을 shared object 형태로 가공한다.
  * ex. [1, 2, 3] -> { 1: 월요일, 2: 화요일, 3: 수요일 }
  */
-export const getSharedDayObjectById = (ids: number[]): OriginalShared => {
+export const getSharedDayObjectById = (ids: AttendanceDay[]): OriginalShared => {
   return ids.reduce((acc, id) => {
     return {
       ...acc,

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,6 @@
 import { NEW_ATTENDANCE_DAY, OriginalShared } from '@/Shared/study';
+import { AttendanceDay } from '@/Types/atoms';
+import { getDay } from 'date-fns';
 
 export const dateFormatter = (date: string) => {
   const [year, month, day] = date.split('-');
@@ -92,3 +94,9 @@ export const getSharedDayObjectById = (ids: number[]): OriginalShared => {
     };
   }, {});
 };
+
+/**
+ * 오늘이 출석일인지 확인한다.
+ */
+export const isTodayAttendanceDay = (attendanceDay: Array<AttendanceDay>) =>
+  attendanceDay.includes(getDay(new Date()) || 7);


### PR DESCRIPTION
![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/23d63ded-66e8-4e8b-b957-da0e5be7994c)

### 💡 다음 이슈를 해결했어요.
- 스터디 진행 중, 오늘이 스터디 진행일이 아닐 시 출석 버튼을 비활성화합니다.
- 스터디 종료 시, 출석 버튼을 화면에서 표시하지 않습니다.
<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- 오늘이 출석일인지 확인하는 코드 추가
  https://github.com/Ludo-SMP/ludo-frontend/blob/a8f62f2cb2e8c670696fd80487fcfed3c14fc2b1/src/utils/date.ts#L96-L100
- 상태에 따라 출석 버튼을 숨기기도, 비활성화할 수 있도록 수정
  https://github.com/Ludo-SMP/ludo-frontend/blob/a8f62f2cb2e8c670696fd80487fcfed3c14fc2b1/src/Pages/StudyDetail/index.tsx#L79-L90
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
