### PR TITLE
플레이스홀더 이미지 배치

### DIFF
--- a/src/Pages/MyPage/StudiesSection.tsx
+++ b/src/Pages/MyPage/StudiesSection.tsx
@@ -6,12 +6,12 @@ import ChipMenu from '@/Components/Common/ChipMenu';
 import { MyStudyCard } from '@/Components/MyStudyCard';
 import { useMyPageInfo } from '@/Hooks/study/useMyPageInfo';
 import { ApplicantRecruitment, CompletedStudy, ParticipateStudy } from '@/Types/study';
-import { useSelectedMyStudyStore } from '@/store/study';
+import { SelectedMyStudyStatus, useSelectedMyStudyStore } from '@/store/study';
 import { getPeriod } from '@/utils/date';
 import { Children, PropsWithChildren, ReactNode } from 'react';
 import styled from 'styled-components';
 import { match } from 'ts-pattern';
-import { LoginFail } from '@/Assets';
+import { LoginFail, SignUpFail } from '@/Assets';
 import { Link } from 'react-router-dom';
 
 const StudiesSection = () => {
@@ -43,19 +43,7 @@ const StudiesSection = () => {
           진행 완료된 스터디
         </ChipMenu>
       </ChipMenusWrapper>
-      <StudyList
-        placeholder={
-          <PlaceHolder>
-            <PlaceHolderInner>
-              <img src={LoginFail} width={294} height={180} alt="no study" />
-              <PlaceHolderTitle>아직 참여 중인 스터디가 없습니다.</PlaceHolderTitle>
-            </PlaceHolderInner>
-            <Button scheme="primary">
-              <Link to="/studies">참여할만한 스터디 찾아보기</Link>
-            </Button>
-          </PlaceHolder>
-        }
-      >
+      <StudyList placeholder={<PlaceHolder tab={selectedMyStudyStatus} />}>
         {match(selectedMyStudyStatus)
           .with('PARTICIPATED', () =>
             participateStudies.map(
@@ -161,7 +149,33 @@ const StudyListInner = styled.ul`
   gap: 12px;
 `;
 
-const PlaceHolder = styled.div`
+const HidableButton = styled(Button)<{
+  $hide?: boolean;
+}>`
+  visibility: ${({ $hide }) => ($hide ? 'hidden' : 'visible')};
+`;
+
+const PlaceHolder = ({ tab }: { tab: SelectedMyStudyStatus['selectedMyStudyStatus'] }) => (
+  <PlaceHolderBox>
+    <PlaceHolderInner>
+      <PlaceHolderTitle>
+        {match(tab)
+          .with('PARTICIPATED', () => '아직 참여 중인 스터디가 없습니다.')
+          .with('APPLIED', () => '지원한 스터디가 없습니다.')
+          .with('COMPLETED', () => '진행 완료된 스터디가 아직 없습니다.')
+          .exhaustive()}
+      </PlaceHolderTitle>
+      <img src={tab === 'COMPLETED' ? SignUpFail : LoginFail} width={294} height={180} alt="no study" />
+    </PlaceHolderInner>
+    {
+      <HidableButton scheme="primary" $hide={tab === 'COMPLETED'}>
+        <Link to="/studies">참여할만한 스터디 찾아보기</Link>
+      </HidableButton>
+    }
+  </PlaceHolderBox>
+);
+
+const PlaceHolderBox = styled.div`
   padding-top: 32px;
   display: flex;
   flex-direction: column;

--- a/src/Pages/MyPage/StudiesSection.tsx
+++ b/src/Pages/MyPage/StudiesSection.tsx
@@ -8,6 +8,7 @@ import { ApplicantRecruitment, CompletedStudy, ParticipateStudy } from '@/Types/
 import { useSelectedMyStudyStore } from '@/store/study';
 import { getPeriod } from '@/utils/date';
 import styled from 'styled-components';
+import { match } from 'ts-pattern';
 
 const StudiesSection = () => {
   const { data: myPageInfo } = useMyPageInfo();
@@ -39,43 +40,73 @@ const StudiesSection = () => {
         </ChipMenu>
       </ChipMenusWrapper>
       <CardListWrapper>
-        {selectedMyStudyStatus === 'PARTICIPATED'
-          ? participateStudies?.map((participateStudy: ParticipateStudy) => (
+        {match(selectedMyStudyStatus)
+          .with('PARTICIPATED', () =>
+            participateStudies.map(
+              ({
+                studyId,
+                title,
+                status,
+                position,
+                startDateTime,
+                endDateTime,
+                participantCount,
+                isOwner,
+                hasRecruitment,
+              }) => (
+                <MyStudyCard
+                  key={studyId}
+                  id={studyId}
+                  title={title}
+                  status={status}
+                  position={position}
+                  period={getPeriod(startDateTime, endDateTime)}
+                  participantCount={participantCount}
+                  isOwner={isOwner}
+                  hasRecruitment={hasRecruitment}
+                />
+              ),
+            ),
+          )
+          .with('APPLIED', () =>
+            applicantRecruitments.map(({ recruitmentId, title, applicantStatus, position }) => (
               <MyStudyCard
-                id={participateStudy?.studyId}
-                title={participateStudy?.title}
-                status={participateStudy.status}
-                position={participateStudy?.position}
-                period={getPeriod(participateStudy?.startDateTime, participateStudy?.endDateTime)}
-                participantCount={participateStudy?.participantCount}
-                isOwner={participateStudy?.isOwner}
-                hasRecruitment={participateStudy?.hasRecruitment}
-                key={participateStudy?.studyId}
+                key={recruitmentId}
+                id={recruitmentId}
+                title={title}
+                status={applicantStatus}
+                position={position}
               />
-            ))
-          : selectedMyStudyStatus === 'APPLIED'
-            ? applicantRecruitments.map((applicantRecruitment: ApplicantRecruitment) => (
+            )),
+          )
+          .with('COMPLETED', () =>
+            completedStudies.map(
+              ({
+                studyId,
+                title,
+                status,
+                position,
+                startDateTime,
+                endDateTime,
+                participantCount,
+                isOwner,
+                hasRecruitment,
+              }) => (
                 <MyStudyCard
-                  id={applicantRecruitment?.recruitmentId}
-                  title={applicantRecruitment?.title}
-                  status={applicantRecruitment?.applicantStatus}
-                  position={applicantRecruitment?.position}
-                  key={applicantRecruitment?.recruitmentId}
+                  key={studyId}
+                  id={studyId}
+                  title={title}
+                  status={status}
+                  position={position}
+                  period={getPeriod(startDateTime, endDateTime)}
+                  participantCount={participantCount}
+                  isOwner={isOwner}
+                  hasRecruitment={hasRecruitment}
                 />
-              ))
-            : completedStudies.map((completedStudy: CompletedStudy) => (
-                <MyStudyCard
-                  id={completedStudy?.studyId}
-                  title={completedStudy?.title}
-                  status={completedStudy?.status}
-                  position={completedStudy?.position}
-                  period={getPeriod(completedStudy?.startDateTime, completedStudy?.endDateTime)}
-                  participantCount={completedStudy?.participantCount}
-                  isOwner={completedStudy?.isOwner}
-                  hasRecruitment={completedStudy?.hasRecruitment}
-                  key={completedStudy?.studyId}
-                />
-              ))}
+              ),
+            ),
+          )
+          .exhaustive()}
       </CardListWrapper>
     </CardsWrapper>
   );

--- a/src/Pages/MyPage/StudiesSection.tsx
+++ b/src/Pages/MyPage/StudiesSection.tsx
@@ -1,14 +1,18 @@
 /** 스따-디 섹션 */
 
 import { StudyInfo } from '@/Assets';
+import Button from '@/Components/Common/Button';
 import ChipMenu from '@/Components/Common/ChipMenu';
 import { MyStudyCard } from '@/Components/MyStudyCard';
 import { useMyPageInfo } from '@/Hooks/study/useMyPageInfo';
 import { ApplicantRecruitment, CompletedStudy, ParticipateStudy } from '@/Types/study';
 import { useSelectedMyStudyStore } from '@/store/study';
 import { getPeriod } from '@/utils/date';
+import { Children, PropsWithChildren, ReactNode } from 'react';
 import styled from 'styled-components';
 import { match } from 'ts-pattern';
+import { LoginFail } from '@/Assets';
+import { Link } from 'react-router-dom';
 
 const StudiesSection = () => {
   const { data: myPageInfo } = useMyPageInfo();
@@ -39,7 +43,19 @@ const StudiesSection = () => {
           진행 완료된 스터디
         </ChipMenu>
       </ChipMenusWrapper>
-      <CardListWrapper>
+      <StudyList
+        placeholder={
+          <PlaceHolder>
+            <PlaceHolderInner>
+              <img src={LoginFail} width={294} height={180} alt="no study" />
+              <PlaceHolderTitle>아직 참여 중인 스터디가 없습니다.</PlaceHolderTitle>
+            </PlaceHolderInner>
+            <Button scheme="primary">
+              <Link to="/studies">참여할만한 스터디 찾아보기</Link>
+            </Button>
+          </PlaceHolder>
+        }
+      >
         {match(selectedMyStudyStatus)
           .with('PARTICIPATED', () =>
             participateStudies.map(
@@ -54,29 +70,26 @@ const StudiesSection = () => {
                 isOwner,
                 hasRecruitment,
               }) => (
-                <MyStudyCard
-                  key={studyId}
-                  id={studyId}
-                  title={title}
-                  status={status}
-                  position={position}
-                  period={getPeriod(startDateTime, endDateTime)}
-                  participantCount={participantCount}
-                  isOwner={isOwner}
-                  hasRecruitment={hasRecruitment}
-                />
+                <li key={studyId}>
+                  <MyStudyCard
+                    id={studyId}
+                    title={title}
+                    status={status}
+                    position={position}
+                    period={getPeriod(startDateTime, endDateTime)}
+                    participantCount={participantCount}
+                    isOwner={isOwner}
+                    hasRecruitment={hasRecruitment}
+                  />
+                </li>
               ),
             ),
           )
           .with('APPLIED', () =>
             applicantRecruitments.map(({ recruitmentId, title, applicantStatus, position }) => (
-              <MyStudyCard
-                key={recruitmentId}
-                id={recruitmentId}
-                title={title}
-                status={applicantStatus}
-                position={position}
-              />
+              <li key={recruitmentId}>
+                <MyStudyCard id={recruitmentId} title={title} status={applicantStatus} position={position} />
+              </li>
             )),
           )
           .with('COMPLETED', () =>
@@ -92,22 +105,23 @@ const StudiesSection = () => {
                 isOwner,
                 hasRecruitment,
               }) => (
-                <MyStudyCard
-                  key={studyId}
-                  id={studyId}
-                  title={title}
-                  status={status}
-                  position={position}
-                  period={getPeriod(startDateTime, endDateTime)}
-                  participantCount={participantCount}
-                  isOwner={isOwner}
-                  hasRecruitment={hasRecruitment}
-                />
+                <li key={studyId}>
+                  <MyStudyCard
+                    id={studyId}
+                    title={title}
+                    status={status}
+                    position={position}
+                    period={getPeriod(startDateTime, endDateTime)}
+                    participantCount={participantCount}
+                    isOwner={isOwner}
+                    hasRecruitment={hasRecruitment}
+                  />
+                </li>
               ),
             ),
           )
           .exhaustive()}
-      </CardListWrapper>
+      </StudyList>
     </CardsWrapper>
   );
 };
@@ -117,17 +131,13 @@ export { StudiesSection };
 const CardsWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   min-height: 368px;
   gap: 24px;
-  align-self: stretch;
 `;
 
 const MyStudyTitleWrapper = styled.div`
   display: flex;
-  align-items: center;
   gap: 8px;
-  align-self: stretch;
 
   span {
     color: ${({ theme }) => theme.color.black5};
@@ -139,15 +149,36 @@ const MyStudyTitleWrapper = styled.div`
   }
 `;
 
-const CardListWrapper = styled.div`
+const StudyList = ({
+  placeholder,
+  children,
+}: PropsWithChildren<{
+  placeholder: ReactNode;
+}>) => (Children.toArray(children).length !== 0 ? <StudyListInner>{children}</StudyListInner> : placeholder);
+const StudyListInner = styled.ul`
   display: flex;
-  width: 100%;
   flex-direction: column;
-  flex-wrap: wrap;
-  align-items: center;
-  align-content: center;
   gap: 12px;
-  align-self: stretch;
+`;
+
+const PlaceHolder = styled.div`
+  padding-top: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+`;
+
+const PlaceHolderInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+`;
+
+const PlaceHolderTitle = styled.span`
+  color: ${({ theme }) => theme.color.black4};
+  ${({ theme }) => theme.typo.ListLabel};
 `;
 
 const ChipMenusWrapper = styled.div`


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
마이페이지의 스터디 목록 탭에서, 참여 중인 / 지원한 / 완료한 스터디가 없을 경우 플레이스홀더 이미지를 표시합니다.

### 참여 / 지원 스터디

![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/4ff70b20-c1f9-4c61-a354-6b13a73e421f)

### 스터디원이 남긴 리뷰

![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/8ff8df8b-4dd7-478e-89be-61eb02b230dc)

### 임시 저장된 글

![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/862bd80d-90db-4664-8772-2ee33051c5fb)

### 루도가 알려요

![image](https://github.com/Ludo-SMP/ludo-frontend/assets/72962900/3de6a830-7c7d-4c73-9e04-8c350e6683d4)

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- (없다면 이 문항을 지워주세요.)
<br><br>

### 💡 필요한 후속작업이 있어요.
- (없다면 이 문항을 지워주세요.)
<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- (없다면 이 문항을 지워주세요.)
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
