### PR TITLE
fix/applicants additionals

### DIFF
--- a/src/Hooks/study/useAcceptApplyMutation.ts
+++ b/src/Hooks/study/useAcceptApplyMutation.ts
@@ -11,7 +11,7 @@ export const useAcceptApplyMutation = (studyId: number, applicantId: number, suc
     mutationKey: [...STUDY.APPLY_ACCEPT(studyId, applicantId)],
     mutationFn: () => acceptApply(studyId, applicantId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [STUDY.APPLICNATS(studyId)] });
+      queryClient.invalidateQueries({ queryKey: [...STUDY.APPLICNATS(studyId)] });
       successHandler();
       openModal();
     },

--- a/src/Pages/Applicants/index.tsx
+++ b/src/Pages/Applicants/index.tsx
@@ -251,7 +251,7 @@ const InfoFields = styled.div`
 
 const Applicants = styled.ul`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(248px, 392px));
   min-width: 300px;
   max-width: 1224px;
   gap: 24px;
@@ -265,7 +265,6 @@ const Applicants = styled.ul`
 // <li> 요소를 넣기 위해 추가적으로 만든 레이어
 const ApplicantLi = styled.li`
   display: flex;
-  justify-content: center;
 
   & > * {
     flex: 1;

--- a/src/Pages/Applicants/index.tsx
+++ b/src/Pages/Applicants/index.tsx
@@ -5,10 +5,9 @@ import { ApplicantCard } from '@/Components/ApplicantCard';
 import { Applicant } from '@/Types/study';
 import Button from '@/Components/Common/Button';
 import { useUserStore } from '@/store/user';
-import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useApplicantsDetail } from '@/Hooks/study/useApplicantsDetail';
 import { useCloseRecruitmentMutation } from '@/Hooks/recruitments/useCloseRecruitmentMutation';
-import { useEffect } from 'react';
 import { RowDivider } from '@/Components/Common/Divider/RowDivider';
 import Footer from '@/Components/Footer';
 
@@ -21,16 +20,6 @@ export const ApplicantsPage = () => {
   const navigate = useNavigate();
 
   const { mutate: closeRecruitmentMutate } = useCloseRecruitmentMutation(studyId);
-
-  const { pathname } = useLocation();
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
-
-  if (isLoading) return <Loading />;
-
-  const isOwner = user?.id === study.owner.id;
 
   return (
     <Page>
@@ -46,33 +35,37 @@ export const ApplicantsPage = () => {
       </Header>
       <RowDivider />
       <Main>
-        <MainInner>
-          <ParentNav studyTitle={study.title} />
-          <InfoSection>
-            <InfoFields>
-              <InfoField title="현재 인원수" content={study.participantCount} flexDirection="column" />
-              <InfoField title="목표 인원수" content={study.participantLimit} flexDirection="column" />
-            </InfoFields>
-            <Applicants>
-              {applicants.map((applicant) => (
-                <ApplicantLi key={applicant.id}>
-                  <ApplicantCard
-                    studyId={studyId}
-                    id={applicant.id}
-                    title={study.title}
-                    nickname={applicant.nickname}
-                    email={applicant.email}
-                    position={applicant.position}
-                    isOwner={isOwner}
-                    reviewStatistics={applicant.reviewStatistics}
-                  />
-                </ApplicantLi>
-              ))}
-            </Applicants>
-          </InfoSection>
-        </MainInner>
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <MainInner>
+            <ParentNav studyTitle={study.title} />
+            <InfoSection>
+              <InfoFields>
+                <InfoField title="현재 인원수" content={study.participantCount} flexDirection="column" />
+                <InfoField title="목표 인원수" content={study.participantLimit} flexDirection="column" />
+              </InfoFields>
+              <Applicants>
+                {applicants.map((applicant) => (
+                  <ApplicantLi key={applicant.id}>
+                    <ApplicantCard
+                      studyId={studyId}
+                      id={applicant.id}
+                      title={study.title}
+                      nickname={applicant.nickname}
+                      email={applicant.email}
+                      position={applicant.position}
+                      isOwner={user?.id === study.owner.id}
+                      reviewStatistics={applicant.reviewStatistics}
+                    />
+                  </ApplicantLi>
+                ))}
+              </Applicants>
+            </InfoSection>
+          </MainInner>
+        )}
       </Main>
-      {isOwner && (
+      {user?.id === study?.owner.id && (
         <CloseSection>
           <CloseSectionInner>
             <Button scheme="secondary" onClick={() => (closeRecruitmentMutate(), navigate('./..'))}>


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- 지원자 수락의 `invalidateQuery` 키를 올바르게 수정했습니다.
- 지원자 카드 그리드가 중앙 정렬되는 이슈를 해결했습니다.
- 로딩 UI를 컴포넌트 트리 내부로 이동해 로딩 중 사용자가 더 많은 UI를 볼 수 있도록 했습니다.
<br><br>

### 💡 필요한 후속작업이 있어요.
- 모달이 query가 갱신되고 아이템이 사라지면서 빠르게 점멸함.
<br><br>

### 💡 다음 자료를 참고하면 좋아요.
- https://studymatchproject.atlassian.net/wiki/spaces/Ludo/pages/44302344/2+-+QA
<br><br>

### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
