### PR TITLE
fix: 스터디원 모집 버튼 -> '스터디 지원자 확인하기'로 이름 변경

### DIFF
--- a/src/Pages/StudyDetail/index.tsx
+++ b/src/Pages/StudyDetail/index.tsx
@@ -141,7 +141,7 @@ export const StudyDetailPage = () => {
                 <MemberCounts count={study?.participants?.length} />
                 {isOwner && (
                   <ApplicationButton>
-                    <Link to={'./applicants'}>스터디원 모집</Link>
+                    <Link to={'./applicants'}>스터디 지원자 확인하기</Link>
                   </ApplicationButton>
                 )}
               </MembersCountBar>


### PR DESCRIPTION
#338 부분 해결

### 💡 다음 이슈를 해결했어요.
- `스터디원 모집` -> `스터디 지원자 확인하기`로 워딩 변경.
<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
