### PR TITLE
SP-669 모집공고 카드의 기술스택이 너무 많을 때 ‘…외 n개'로 표기 

### DIFF
--- a/src/Components/RecruitmentCard/index.tsx
+++ b/src/Components/RecruitmentCard/index.tsx
@@ -8,6 +8,7 @@ import { PROGRESS_METHOD } from '@/Shared/study';
 import Image from '../Common/Image';
 import { Views } from '@/Assets';
 import { media, textEllipsis } from '@/Styles/theme';
+import { VISIBLE_STACK_COUNT } from '@/Constants/common';
 
 /** 스터디 모집 공고 */
 const RecruitmentCard = (recruitment: Recruitment) => {
@@ -53,7 +54,9 @@ const RecruitmentCard = (recruitment: Recruitment) => {
             ) : (
               <Image size={32} />
             )}
-            {recruitment.stacks.length > 5 && <StackCountText> 외 {recruitment.stacks.length - 5}개</StackCountText>}
+            {recruitment.stacks.length > VISIBLE_STACK_COUNT && (
+              <StackCountText> 외 {recruitment.stacks.length - 5}개</StackCountText>
+            )}
           </div>
         </StudyDetailInfoWrapper>
         <StudyAdditionalInfoWrapper>

--- a/src/Components/RecruitmentCard/index.tsx
+++ b/src/Components/RecruitmentCard/index.tsx
@@ -44,12 +44,16 @@ const RecruitmentCard = (recruitment: Recruitment) => {
           </div>
           <div className="study__stacks">
             {recruitment.stacks.length !== 0 ? (
-              recruitment.stacks.map((stack: Stack) => (
-                <Image key={stack.id} size={32} src={`${import.meta.env.VITE_BASE_API_URL}${stack.imageUrl}`} />
-              ))
+              recruitment.stacks.map(
+                (stack: Stack, idx) =>
+                  idx < 5 && (
+                    <Image key={stack.id} size={32} src={`${import.meta.env.VITE_BASE_API_URL}${stack.imageUrl}`} />
+                  ),
+              )
             ) : (
               <Image size={32} />
             )}
+            {recruitment.stacks.length > 5 && <StackCountText> 외 {recruitment.stacks.length - 5}개</StackCountText>}
           </div>
         </StudyDetailInfoWrapper>
         <StudyAdditionalInfoWrapper>
@@ -213,4 +217,10 @@ const StudyAdditionalInfoWrapper = styled.div`
   }
 `;
 
+const StackCountText = styled.span`
+  font-size: ${(props) => props.theme.font.small};
+  font-weight: 500;
+  line-height: 40px;
+  color: ${(props) => props.theme.color.black2};
+`;
 export default RecruitmentCard;

--- a/src/Components/RecruitmentCard/index.tsx
+++ b/src/Components/RecruitmentCard/index.tsx
@@ -225,5 +225,6 @@ const StackCountText = styled.span`
   font-weight: 500;
   line-height: 40px;
   color: ${(props) => props.theme.color.black2};
+  padding-left: 0.5rem;
 `;
 export default RecruitmentCard;

--- a/src/Constants/common.ts
+++ b/src/Constants/common.ts
@@ -1,2 +1,3 @@
 export const INFINITE_RECRUITMENTS_COUMT_PER_PAGE = 21;
+export const VISIBLE_STACK_COUNT = 5;
 export const NOTION_URL = 'https://coherent-stool-91c.notion.site/Ludo-3b08f55b652b475c991bfadf372e6f33';


### PR DESCRIPTION
**Closes #350** 
### 💡 다음 이슈를 해결했어요.
- [x] 모집공고 카드의 기술스택이 너무 많을 때 ‘~외  n개'로 표기  

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
스택의 개수가 최대 5개까지 보이도록 하였고, 5개 초과인 경우 `외 (전체 스택의 개수 - 5)개`의 텍스트가 표시되도록 하였습니다.

https://github.com/Ludo-SMP/ludo-frontend/blob/e9c31317de6b65a64eb6db62cb8145531051d40a/src/Components/RecruitmentCard/index.tsx#L46-L60

<img width="600" alt="image" src="https://github.com/user-attachments/assets/552856f2-cbdc-4026-b485-01dae42a9766">

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
