### PR TITLE
SP-665 진행방식 Dropdown 필터에서 오프라인이 2개인 버그 수정

### DIFF
--- a/src/Components/DropdownFilter/DropdownItem/index.tsx
+++ b/src/Components/DropdownFilter/DropdownItem/index.tsx
@@ -10,7 +10,11 @@ export interface DropdownItemProps {
 const DropdownItem = ({ item, filterOption, handleClick }: DropdownItemProps) => {
   return (
     <DropdownItemWrapper onClick={handleClick}>
-      {filterOption === 'PROGRESS_METHOD' && item.id !== 0 ? (item.id === 1 ? '온라인' : '오프라인') : item.name}
+      {filterOption === 'PROGRESS_METHOD' && Number(item.id) !== 0
+        ? Number(item.id) === 1
+          ? '온라인'
+          : '오프라인'
+        : item.name}
     </DropdownItemWrapper>
   );
 };


### PR DESCRIPTION
**Closes #357**  

### 💡 다음 이슈를 해결했어요.
- SP-665 진행방식 Dropdown 필터에서 오프라인이 2개인 버그 수정

<br><br>
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
item.id를 숫자형으로 형변환 하여, 올바른 strict equality가 적용되도록 하였습니다.

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.